### PR TITLE
Fix: Configure backend API URL via environment variable

### DIFF
--- a/DEPLOYMENT_INSTRUCTIONS.md
+++ b/DEPLOYMENT_INSTRUCTIONS.md
@@ -1,0 +1,11 @@
+# Deployment Instructions
+
+When deploying the frontend, you need to set the `VITE_API_BASE_URL` environment variable to the absolute URL of your backend API.
+
+For example, if your backend API is accessible at `https://api.example.com`, you should set the `VITE_API_BASE_URL` environment variable to `https://api.example.com` when building the frontend.
+
+How you set the environment variable depends on your deployment platform:
+
+*   **Docker:** If you're using Docker, you can set the environment variable in your `Dockerfile` or during the `docker run` command.
+*   **Netlify/Vercel/etc.:** If you're using a platform like Netlify or Vercel, you can usually set environment variables in the project settings.
+*   **Other platforms:** Consult the documentation for your specific deployment platform to learn how to set environment variables.

--- a/frontend/src/pages/Record.tsx
+++ b/frontend/src/pages/Record.tsx
@@ -39,7 +39,7 @@ export default function Record() {
   /* ───────────── helpers ─────────────────────────────────────────────── */
 
   async function createMeeting() {
-    const res = await fetch("/api/meetings", {
+    const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/meetings`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ 
@@ -63,7 +63,7 @@ export default function Record() {
     
     try {
       console.log(`Uploading chunk ${index}, size: ${blob.size} bytes, final: ${isFinal}`);
-      const response = await fetch("/api/chunks", { method: "POST", body: fd });
+      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/chunks`, { method: "POST", body: fd });
       const result = await response.json();
       
       if (result.ok && !result.skipped) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,14 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  build: { outDir: "dist", emptyOutDir: true }
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    build: { outDir: "dist", emptyOutDir: true },
+    define: {
+      'import.meta.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL)
+    }
+  }
 });
 


### PR DESCRIPTION
This change allows the frontend to connect to a backend API at a configurable URL.

Previously, the frontend used relative URLs for API requests, which caused issues when the frontend and backend were hosted on different domains or ports.

This commit introduces the following changes:

- Modified `frontend/src/pages/Record.tsx` to use the `VITE_API_BASE_URL` environment variable for API calls.
- Updated `frontend/vite.config.ts` to define the `VITE_API_BASE_URL` environment variable during build.
- Added `DEPLOYMENT_INSTRUCTIONS.md` to explain how to set the `VITE_API_BASE_URL` environment variable during deployment.