### PR TITLE
Fix: Ensure summarization on final empty chunk

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -138,16 +138,20 @@ async def upload_chunk(
         if size_kb < 1:
             LOGGER.warning("⚠️  chunk %d too small – skipped", chunk_index)
             chunk_path.unlink(missing_ok=True)
-            if is_final and mtg.transcript_text:
-                # Generate summary even if final chunk is empty
-                if not mtg.summary_markdown:
-                    mtg.summary_markdown = summarise(mtg.transcript_text)
-                    mtg.done = True
-                    LOGGER.info("✅  meeting %s completed with summary", meeting_id)
             
-            db.add(mtg)
-            db.commit()
-            return {"ok": True, "skipped": True, "done": mtg.done}
+            # If this tiny chunk is also the final one, we still want to proceed to normal finalization
+            # So, only return early if it's NOT the final chunk.
+            if not is_final:
+                db.add(mtg) # Save any potential previous changes to mtg
+                db.commit()
+                return {"ok": True, "skipped": True, "done": mtg.done}
+            else:
+                # It IS the final chunk, but it's tiny. Log it and let the main summarization logic handle it.
+                # We don't do `db.add(mtg)` or `db.commit()` here to avoid overwriting data
+                # before the main summarization logic if mtg.transcript_text was updated by a previous chunk
+                # in the same session but not yet committed.
+                LOGGER.info("🗑️  Final chunk was tiny/empty, proceeding to finalize meeting %s", meeting_id)
+                # The function will now continue to the main summarization block
 
         # **REAL-TIME TRANSCRIPTION**: Process each chunk immediately
         try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,8 @@ from typing import List
 import av
 import openai
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
 from fastapi.responses import JSONResponse
 from sqlmodel import Session, SQLModel, create_engine
 
@@ -21,6 +23,8 @@ from .config import settings
 from .models import Meeting, MeetingCreate, MeetingRead
 
 # ────────────────────────────── setup ─────────────────────────────────────────
+
+
 LOGGER = logging.getLogger("meetscribe")
 logging.basicConfig(
     level=logging.INFO,
@@ -98,7 +102,13 @@ def summarise(text: str) -> str:
 
 # ─────────────────── FastAPI application ─────────────────────────────────────
 app = FastAPI(title="MeetScribe MVP")
-
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allows all origins
+    allow_credentials=True,
+    allow_methods=["*"],  # Allows all methods
+    allow_headers=["*"],  # Allows all headers
+)
 
 @app.post("/api/meetings", response_model=MeetingRead, status_code=201)
 def create_meeting(body: MeetingCreate):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,6 @@ from typing import List
 import av
 import openai
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlmodel import Session, SQLModel, create_engine
 
@@ -99,14 +98,6 @@ def summarise(text: str) -> str:
 
 # ─────────────────── FastAPI application ─────────────────────────────────────
 app = FastAPI(title="MeetScribe MVP")
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],  # Allows all origins
-    allow_credentials=True,
-    allow_methods=["*"],  # Allows all methods
-    allow_headers=["*"],  # Allows all headers
-)
 
 
 @app.post("/api/meetings", response_model=MeetingRead, status_code=201)


### PR DESCRIPTION
The summarization process was not reliably triggered if the final audio chunk sent to the backend was empty or very small. This is because the frontend sends an empty blob as the final chunk when stopping a recording.

The backend logic for handling tiny chunks would identify this final empty chunk as "skipped" and, under certain race conditions where the accumulated transcript (`mtg.transcript_text`) hadn't fully updated in the database record, it would fail to trigger summarization or return before the main summarization logic block was reached.

This commit modifies the `upload_chunk` function in `backend/app/main.py`. If a chunk is identified as tiny:
- If it's *not* the final chunk, it's skipped, and the function returns early as before.
- If it *is* the final chunk (even if tiny/empty), the function now bypasses the early return. It logs that the final chunk was tiny and proceeds to the main, existing summarization logic block at the end of the function. This ensures that the accumulated transcript from all previous (non-empty) chunks is used for summarization, regardless of the state of the very last chunk signal.