### PR TITLE
🗣️ Local speaker diarization (who said what), on-device

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -37,6 +37,36 @@ FRONTEND_ORIGIN=http://localhost:4132
 # VITE_API_BASE_URL=https://api.your-domain.com
 # FRONTEND_ORIGIN=https://app.your-domain.com
 
+# ===== Speaker diarization (local, CPU) =====
+# After a meeting ends, the recording is analysed locally to label the
+# transcript with Speaker 1..N before it is summarized. Runs entirely on your
+# machine — no audio leaves it for this step — and needs ffmpeg plus the models
+# (~36 MB, downloaded automatically on first start).
+DIARIZATION_ENABLED=true
+
+# Clustering threshold. LOWER splits speakers apart, HIGHER merges them.
+# Measured on two real recordings (raw -> after noise pruning):
+#   clean parliament debate, 3-4 speakers:  0.6 -> 5 -> 3   |  0.9 -> 1 (collapsed)
+#   noisy outdoor conversation, 3 speakers: 0.6 -> 11 -> 4
+# Lower it if distinct people get merged; raise it if one person appears as
+# several speakers.
+DIARIZATION_CLUSTER_THRESHOLD=0.6
+
+# Clusters holding less than this share of the speech AND less than
+# DIARIZATION_MIN_SPEAKER_SECONDS of it are treated as noise and folded into the
+# nearest real speaker. This is what makes one threshold work both indoors and
+# outdoors.
+DIARIZATION_MIN_SPEAKER_SHARE=0.06
+DIARIZATION_MIN_SPEAKER_SECONDS=8.0
+
+# ONNX threads per job, and how many meetings may diarize at once. The defaults
+# suit a 6-thread CPU serving a few concurrent users: 2 jobs x 2 threads.
+DIARIZATION_THREADS=2
+DIARIZATION_MAX_CONCURRENT=2
+
+# Where the models live. Defaults to backend/data/models.
+# DIARIZATION_MODEL_DIR=
+
 # ===== Performance Tuning =====
 # Set the number of threads for OpenBLAS (used by Whisper's underlying libraries).
 # Adjust based on your server's CPU cores. Default is 6.

--- a/.env.sample
+++ b/.env.sample
@@ -58,6 +58,11 @@ DIARIZATION_CLUSTER_THRESHOLD=0.9
 # a few seconds is <1% of a long meeting, which is what caused 13+ speakers.
 DIARIZATION_MIN_SPEAKER_SHARE=0.06
 
+# How far the analysis window advances (fraction of its length). The library
+# default 0.1 overlaps windows by 90%, doing ~10x redundant work; 0.5 measured
+# 4.9x faster and slightly more accurate across six recordings.
+DIARIZATION_WINDOW_SHIFT_RATIO=0.5
+
 # ONNX threads per job, and concurrent diarization jobs. Defaults suit a
 # 6-thread CPU serving a few users: 2 jobs x 2 threads.
 DIARIZATION_THREADS=2

--- a/.env.sample
+++ b/.env.sample
@@ -38,33 +38,32 @@ FRONTEND_ORIGIN=http://localhost:4132
 # FRONTEND_ORIGIN=https://app.your-domain.com
 
 # ===== Speaker diarization (local, CPU) =====
-# After a meeting ends, the recording is analysed locally to label the
-# transcript with Speaker 1..N before it is summarized. Runs entirely on your
-# machine — no audio leaves it for this step — and needs ffmpeg plus the models
-# (~36 MB, downloaded automatically on first start).
+# After a meeting ends, the recording is analysed locally and the transcript is
+# labelled Speaker 1..N before summarization. Nothing leaves your machine.
+# Needs ffmpeg plus ~36 MB of models, downloaded automatically on first start.
 DIARIZATION_ENABLED=true
 
-# Clustering threshold. LOWER splits speakers apart, HIGHER merges them.
-# Measured on two real recordings (raw -> after noise pruning):
-#   clean parliament debate, 3-4 speakers:  0.6 -> 5 -> 3   |  0.9 -> 1 (collapsed)
-#   noisy outdoor conversation, 3 speakers: 0.6 -> 11 -> 4
-# Lower it if distinct people get merged; raise it if one person appears as
-# several speakers.
-DIARIZATION_CLUSTER_THRESHOLD=0.6
+# Benchmarked on 4 x 21-min AMI meetings (4 speakers each) + 2 own recordings.
+# Mean DER / detected speaker counts:
+#   campplus @0.90  23.7%  4,3,3,4  <- default, and ~2x cheaper
+#   eres2net @0.95  25.7%  3,3,2,4
+#   wespeaker@0.60  60.7%  13,15,14,14
+DIARIZATION_EMBEDDING_MODEL=3dspeaker_speech_campplus_sv_zh-cn_16k-common.onnx
 
-# Clusters holding less than this share of the speech AND less than
-# DIARIZATION_MIN_SPEAKER_SECONDS of it are treated as noise and folded into the
-# nearest real speaker. This is what makes one threshold work both indoors and
-# outdoors.
+# Clustering threshold: higher merges speakers, lower splits them.
+DIARIZATION_CLUSTER_THRESHOLD=0.9
+
+# Clusters below this share of total speech are treated as noise and folded
+# into the nearest real speaker. Do not add an absolute-seconds exception:
+# a few seconds is <1% of a long meeting, which is what caused 13+ speakers.
 DIARIZATION_MIN_SPEAKER_SHARE=0.06
-DIARIZATION_MIN_SPEAKER_SECONDS=8.0
 
-# ONNX threads per job, and how many meetings may diarize at once. The defaults
-# suit a 6-thread CPU serving a few concurrent users: 2 jobs x 2 threads.
+# ONNX threads per job, and concurrent diarization jobs. Defaults suit a
+# 6-thread CPU serving a few users: 2 jobs x 2 threads.
 DIARIZATION_THREADS=2
 DIARIZATION_MAX_CONCURRENT=2
 
-# Where the models live. Defaults to backend/data/models.
+# Where models live. Defaults to backend/data/models.
 # DIARIZATION_MODEL_DIR=
 
 # ===== Performance Tuning =====

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ All configuration lives in a single `.env` file in the project root.
 | `DIARIZATION_EMBEDDING_MODEL` | Speaker-embedding model. Biggest single lever on accuracy — see `.env.sample` for benchmarks. | `campplus` |
 | `DIARIZATION_CLUSTER_THRESHOLD` | Higher merges speakers, lower splits them. | `0.9` |
 | `DIARIZATION_MIN_SPEAKER_SHARE` | Clusters below this share of speech are folded into the nearest speaker. | `0.06` |
+| `DIARIZATION_WINDOW_SHIFT_RATIO` | Window advance. Higher is much faster; 0.5 measured 4.9x faster than the library default. | `0.5` |
 | `DIARIZATION_THREADS` / `DIARIZATION_MAX_CONCURRENT` | Threads per job, and concurrent jobs. | `2` / `2` |
 | `WORKER_THREADS` | Number of background threads for transcription/summarization. | `4` |
 | `OPENBLAS_NUM_THREADS` | CPU threads for Whisper's underlying math libraries. | `6` |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ever been in back-to-back meetings, frantically trying to type notes while also 
       * **Local or Cloud Transcription:** Uses the high-quality `whisper-large-v3` model for speech-to-text. You can configure it to run on your own hardware for maximum privacy or use a faster cloud API (Groq) for transcription.
       * **Intelligent Summarization:** Leverages Claude (Anthropic) for intelligent, context-aware summaries with a sophisticated prompting strategy that ensures high-quality, structured output.
   * **📊 Comprehensive Admin Dashboard:** A dashboard page gives a full overview of platform usage, device statistics, user feedback trends, and interesting facts like the "busiest hour" and "most active day".
+  * **🗣️ Speaker Labels (local):** After the meeting, the recording is diarized **on your own machine** (ONNX/CPU, no PyTorch, nothing uploaded) and the transcript is labelled `Speaker 1`, `Speaker 2`, … before summarization — so the summary can attribute decisions and action items to the right person. Names stay out of it; Claude may infer them from context.
   * **🎤 Live Transcription:** See the text appear in near real-time as you speak, so you know it's working.
   * **🔒 Private & Self-Hostable:** Your recordings and transcripts are processed on your own server, not a third-party service. Run it on your own machine or cloud server.
   * **⚡ Offline-Ready History:** Your past meeting summaries are cached in your browser, so you can access them instantly without hitting the server again.
@@ -171,6 +172,10 @@ All configuration lives in a single `.env` file in the project root.
 | **`SECRET_KEY`** | **Required.** A random string for signing session data. Change this. | — |
 | `VITE_API_BASE_URL` | Public URL of the backend API. Leave blank for local Docker (handled by nginx proxy). | (blank) |
 | `FRONTEND_ORIGIN` | Frontend URL for backend CORS. | `http://localhost:4132` |
+| **`DIARIZATION_ENABLED`** | Label the transcript with `Speaker 1..N` after the meeting, locally on CPU. | `true` |
+| `DIARIZATION_CLUSTER_THRESHOLD` | Lower splits speakers apart, higher merges them. See `.env.sample` for measured values. | `0.6` |
+| `DIARIZATION_MIN_SPEAKER_SHARE` / `_SECONDS` | Clusters below both are treated as noise and folded into the nearest speaker. | `0.06` / `8.0` |
+| `DIARIZATION_THREADS` / `DIARIZATION_MAX_CONCURRENT` | ONNX threads per job, and concurrent diarization jobs. | `2` / `2` |
 | `WORKER_THREADS` | Number of background threads for transcription/summarization. | `4` |
 | `OPENBLAS_NUM_THREADS` | CPU threads for Whisper's underlying math libraries. | `6` |
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,10 @@ All configuration lives in a single `.env` file in the project root.
 | `VITE_API_BASE_URL` | Public URL of the backend API. Leave blank for local Docker (handled by nginx proxy). | (blank) |
 | `FRONTEND_ORIGIN` | Frontend URL for backend CORS. | `http://localhost:4132` |
 | **`DIARIZATION_ENABLED`** | Label the transcript with `Speaker 1..N` after the meeting, locally on CPU. | `true` |
-| `DIARIZATION_CLUSTER_THRESHOLD` | Lower splits speakers apart, higher merges them. See `.env.sample` for measured values. | `0.6` |
-| `DIARIZATION_MIN_SPEAKER_SHARE` / `_SECONDS` | Clusters below both are treated as noise and folded into the nearest speaker. | `0.06` / `8.0` |
-| `DIARIZATION_THREADS` / `DIARIZATION_MAX_CONCURRENT` | ONNX threads per job, and concurrent diarization jobs. | `2` / `2` |
+| `DIARIZATION_EMBEDDING_MODEL` | Speaker-embedding model. Biggest single lever on accuracy — see `.env.sample` for benchmarks. | `campplus` |
+| `DIARIZATION_CLUSTER_THRESHOLD` | Higher merges speakers, lower splits them. | `0.9` |
+| `DIARIZATION_MIN_SPEAKER_SHARE` | Clusters below this share of speech are folded into the nearest speaker. | `0.06` |
+| `DIARIZATION_THREADS` / `DIARIZATION_MAX_CONCURRENT` | Threads per job, and concurrent jobs. | `2` / `2` |
 | `WORKER_THREADS` | Number of background threads for transcription/summarization. | `4` |
 | `OPENBLAS_NUM_THREADS` | CPU threads for Whisper's underlying math libraries. | `6` |
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,30 +33,32 @@ class Settings(BaseSettings):
     # transcript with Speaker 1..N before it is sent for summarization.
     diarization_enabled: bool = True
     diarization_model_dir: Path = BASE_DIR / "data" / "models"
-    # Cosine threshold for speaker clustering. Higher merges speakers together;
-    # lower splits them apart. Measured on two real recordings:
+    # Speaker-embedding model. Measured over four 21-minute AMI meetings
+    # (mean DER, 0.25s collar) plus two of our own recordings:
     #
-    #   Bundestag debate, ~3-4 speakers, clean audio:
-    #     0.4 -> 7 | 0.5 -> 5 | 0.7 -> 3 | 0.8 -> 2 | 0.9 -> 1 (all collapsed)
-    #   Outdoor conversation, ~3 speakers, noisy and sparse:
-    #     0.5 -> 15 | 0.7 -> 7 | 0.9 -> 3
+    #   campplus @0.90   DER 23.7   speakers 4,3,3,4 (truth 4)   RTF ~0.08
+    #   eres2net @0.95   DER 25.7   speakers 3,3,2,4             RTF ~0.15-0.41
+    #   wespeaker@0.60   DER 60.7   speakers 13,15,14,14         RTF ~0.07
     #
-    # Clean speech tolerates a lower threshold than noisy speech. 0.6 is paired
-    # with the minor-cluster pruning below, which together handle both cases:
+    # campplus wins on accuracy, on speaker count, and on cost. It is trained
+    # on Chinese yet transfers well to English, German and Russian — speaker
+    # embeddings are far less language-bound than they look.
+    diarization_embedding_model: str = "3dspeaker_speech_campplus_sv_zh-cn_16k-common.onnx"
+    # Cosine threshold for clustering. Higher merges speakers, lower splits
+    # them. 0.90 matches sherpa-onnx's own recommendation; 0.60 (our first
+    # guess) produced 13-15 speakers in a 4-person meeting because the optimal
+    # value drifts badly with recording length.
+    diarization_cluster_threshold: float = 0.9
+    # A speaker cluster holding less than this share of the speech is treated as
+    # noise and folded into the nearest real speaker.
     #
-    #                                    raw -> pruned   (ground truth)
-    #   clean parliament debate           5   -> 3        (3-4)
-    #   noisy outdoor conversation       11   -> 4        (3)
-    #
-    # Lower this if distinct speakers are being merged; raise it if one person
-    # keeps appearing under several labels.
-    diarization_cluster_threshold: float = 0.6
-    # A speaker cluster is treated as noise — and folded into the nearest real
-    # speaker — when it holds less than this share of the speech AND less than
-    # `min_speaker_seconds` of it. The absolute floor keeps genuinely quiet
-    # participants in long meetings, where anyone is a tiny share of the total.
+    # There is deliberately NO absolute-seconds escape hatch. An earlier
+    # "6% share OR 8 seconds" rule was meant to protect quiet participants, but
+    # 8s is under 1% of a 21-minute meeting, so nearly every noise cluster
+    # survived it — that single clause was most of why long meetings reported
+    # 13+ speakers. The cost is that someone speaking under ~6% of the time
+    # gets merged into a neighbour, which barely affects a summary.
     diarization_min_speaker_share: float = 0.06
-    diarization_min_speaker_seconds: float = 8.0
     # Ignore speech/silence runs shorter than these (seconds). Short bursts
     # produce unreliable embeddings and inflate the speaker count.
     diarization_min_duration_on: float = 0.5

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,45 @@ class Settings(BaseSettings):
     # Seconds of inactivity before a recording is auto-finalized
     inactivity_timeout_seconds: int = 120
 
+    # ===== Speaker diarization (local, CPU) =====
+    # Runs after the meeting ends, over the concatenated audio, and labels the
+    # transcript with Speaker 1..N before it is sent for summarization.
+    diarization_enabled: bool = True
+    diarization_model_dir: Path = BASE_DIR / "data" / "models"
+    # Cosine threshold for speaker clustering. Higher merges speakers together;
+    # lower splits them apart. Measured on two real recordings:
+    #
+    #   Bundestag debate, ~3-4 speakers, clean audio:
+    #     0.4 -> 7 | 0.5 -> 5 | 0.7 -> 3 | 0.8 -> 2 | 0.9 -> 1 (all collapsed)
+    #   Outdoor conversation, ~3 speakers, noisy and sparse:
+    #     0.5 -> 15 | 0.7 -> 7 | 0.9 -> 3
+    #
+    # Clean speech tolerates a lower threshold than noisy speech. 0.6 is paired
+    # with the minor-cluster pruning below, which together handle both cases:
+    #
+    #                                    raw -> pruned   (ground truth)
+    #   clean parliament debate           5   -> 3        (3-4)
+    #   noisy outdoor conversation       11   -> 4        (3)
+    #
+    # Lower this if distinct speakers are being merged; raise it if one person
+    # keeps appearing under several labels.
+    diarization_cluster_threshold: float = 0.6
+    # A speaker cluster is treated as noise — and folded into the nearest real
+    # speaker — when it holds less than this share of the speech AND less than
+    # `min_speaker_seconds` of it. The absolute floor keeps genuinely quiet
+    # participants in long meetings, where anyone is a tiny share of the total.
+    diarization_min_speaker_share: float = 0.06
+    diarization_min_speaker_seconds: float = 8.0
+    # Ignore speech/silence runs shorter than these (seconds). Short bursts
+    # produce unreliable embeddings and inflate the speaker count.
+    diarization_min_duration_on: float = 0.5
+    diarization_min_duration_off: float = 0.5
+    # ONNX threads per diarization job. Kept small so several concurrent
+    # meetings can share a modest CPU without thrashing.
+    diarization_threads: int = 2
+    # How many meetings may diarize at once; the rest queue.
+    diarization_max_concurrent: int = 2
+
 
 @lru_cache
 def get_settings() -> "Settings":

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -59,6 +59,12 @@ class Settings(BaseSettings):
     # 13+ speakers. The cost is that someone speaking under ~6% of the time
     # gets merged into a neighbour, which barely affects a summary.
     diarization_min_speaker_share: float = 0.06
+    # How far the segmentation window advances, as a fraction of its length.
+    # sherpa-onnx defaults to 0.1 — a 90% overlap that analyses every moment
+    # about ten times over. Measured across six recordings, 0.5 is 4.9x faster
+    # AND slightly more accurate (mean DER 22.6% vs 23.7%), with identical
+    # speaker counts, so the overlap was buying nothing.
+    diarization_window_shift_ratio: float = 0.5
     # Ignore speech/silence runs shorter than these (seconds). Short bursts
     # produce unreliable embeddings and inflate the speaker count.
     diarization_min_duration_on: float = 0.5

--- a/backend/app/diarization.py
+++ b/backend/app/diarization.py
@@ -36,7 +36,6 @@ LOGGER = logging.getLogger("meetscribe_diarization")
 
 SAMPLE_RATE = 16_000
 SEGMENTATION_MODEL = Path("sherpa-onnx-pyannote-segmentation-3-0") / "model.int8.onnx"
-EMBEDDING_MODEL = Path("wespeaker_en_voxceleb_CAM++.onnx")
 
 # One diarizer per concurrency slot: checking one out guarantees no two threads
 # call process() on the same object, while still amortizing model loading.
@@ -52,8 +51,10 @@ class SpeakerTurn:
 
 
 def model_paths() -> tuple[Path, Path]:
+    """(segmentation, embedding) model paths. The embedder is configurable
+    because which one is used matters more than any other single setting."""
     root = Path(settings.diarization_model_dir)
-    return root / SEGMENTATION_MODEL, root / EMBEDDING_MODEL
+    return root / SEGMENTATION_MODEL, root / settings.diarization_embedding_model
 
 
 def models_available() -> bool:
@@ -173,15 +174,16 @@ def _prune_minor_speakers(turns: list[SpeakerTurn]) -> list[SpeakerTurn]:
     Background noise, laughter and one-word interjections produce unreliable
     embeddings, and each fragment tends to become its own "speaker". Without
     this, noisy recordings invent a dozen speakers; with it, one threshold works
-    for both clean and noisy audio. Measured speaker counts (ground truth in
-    brackets) at threshold 0.6:
+    for both clean and noisy audio. Measured on four 21-minute AMI meetings at
+    threshold 0.90, true speaker count 4 in every case:
 
-        clean parliament debate [3-4]: 5 raw -> 3 pruned
-        noisy outdoor conversation [3]: 11 raw -> 4 pruned
+        raw clusters:  21, 18, 19, 21
+        after pruning:  4,  3,  3,  4
 
-    A cluster survives if it holds a meaningful *share* of the speech OR enough
-    absolute speech — the second test matters in long meetings, where a genuine
-    but quiet participant is a tiny fraction of the total.
+    A cluster survives on its *share* of the speech alone. An earlier version
+    also let a cluster through on absolute duration ("or >= 8 seconds"), which
+    backfired: 8s is under 1% of a 21-minute meeting, so almost every noise
+    cluster qualified, and long meetings reported 13+ speakers.
     """
     if not turns:
         return turns
@@ -195,7 +197,6 @@ def _prune_minor_speakers(turns: list[SpeakerTurn]) -> list[SpeakerTurn]:
         speaker
         for speaker, seconds in talk.items()
         if seconds / total >= settings.diarization_min_speaker_share
-        or seconds >= settings.diarization_min_speaker_seconds
     }
     if not major or len(major) == len(talk):
         return turns

--- a/backend/app/diarization.py
+++ b/backend/app/diarization.py
@@ -1,0 +1,383 @@
+"""
+app/diarization.py
+────────────────────────────────────────────────────────
+Local, CPU-only speaker diarization.
+
+Runs once, after a meeting ends, over the concatenated audio. Transcription is
+untouched: we reuse the words Whisper already produced and only attach a
+speaker label to each of its segments, so the text sent for summarization is
+identical to what it would have been without diarization.
+
+Two things here are load-bearing:
+
+1. Chunks are NOT 30 seconds. Measured on a real recording, chunk 0 was 44.6s
+   and by chunk 11 the naive `index * 30` assumption was off by +23s. Absolute
+   positions therefore come from actual decoded sample counts, never from the
+   chunk index.
+2. Diarization is best-effort. If the models are missing or anything throws,
+   the caller falls back to the plain transcript rather than losing a summary.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .config import settings
+
+LOGGER = logging.getLogger("meetscribe_diarization")
+
+SAMPLE_RATE = 16_000
+SEGMENTATION_MODEL = Path("sherpa-onnx-pyannote-segmentation-3-0") / "model.int8.onnx"
+EMBEDDING_MODEL = Path("wespeaker_en_voxceleb_CAM++.onnx")
+
+# One diarizer per concurrency slot: checking one out guarantees no two threads
+# call process() on the same object, while still amortizing model loading.
+_pool: queue.Queue = queue.Queue()
+_pool_filled = False
+
+
+@dataclass
+class SpeakerTurn:
+    start: float
+    end: float
+    speaker: int
+
+
+def model_paths() -> tuple[Path, Path]:
+    root = Path(settings.diarization_model_dir)
+    return root / SEGMENTATION_MODEL, root / EMBEDDING_MODEL
+
+
+def models_available() -> bool:
+    return all(p.exists() for p in model_paths())
+
+
+def is_enabled() -> bool:
+    if not settings.diarization_enabled:
+        return False
+    if not models_available():
+        seg, emb = model_paths()
+        LOGGER.warning(
+            "Diarization enabled but models are missing (%s, %s). Skipping speaker labels.",
+            seg,
+            emb,
+        )
+        return False
+    return True
+
+
+def _build_diarizer():
+    import sherpa_onnx as so
+
+    seg, emb = model_paths()
+    config = so.OfflineSpeakerDiarizationConfig(
+        segmentation=so.OfflineSpeakerSegmentationModelConfig(
+            pyannote=so.OfflineSpeakerSegmentationPyannoteModelConfig(model=str(seg)),
+            num_threads=settings.diarization_threads,
+        ),
+        embedding=so.SpeakerEmbeddingExtractorConfig(
+            model=str(emb), num_threads=settings.diarization_threads
+        ),
+        clustering=so.FastClusteringConfig(
+            num_clusters=-1, threshold=settings.diarization_cluster_threshold
+        ),
+        min_duration_on=settings.diarization_min_duration_on,
+        min_duration_off=settings.diarization_min_duration_off,
+    )
+    if not config.validate():
+        raise RuntimeError("Invalid diarization configuration")
+    return so.OfflineSpeakerDiarization(config)
+
+
+def _acquire_diarizer():
+    """Check out a diarizer, blocking while all concurrency slots are busy."""
+    global _pool_filled
+    if not _pool_filled:
+        # Sentinels, not instances: models load lazily on first real use, so a
+        # server that never records anything pays nothing.
+        for _ in range(max(1, settings.diarization_max_concurrent)):
+            _pool.put(None)
+        _pool_filled = True
+
+    slot = _pool.get()  # blocks; this is also the concurrency limit
+    if slot is None:
+        LOGGER.info(
+            "Loading diarization models (threads=%d)…", settings.diarization_threads
+        )
+        slot = _build_diarizer()
+    return slot
+
+
+def _release_diarizer(slot) -> None:
+    _pool.put(slot)
+
+
+def decode_to_pcm(
+    chunk_paths: list[tuple[int, Path]], workdir: Path
+) -> tuple[Path, dict[int, tuple[float, float]], float]:
+    """
+    Decode chunks into one raw float32 mono stream on disk.
+
+    Streaming to disk keeps peak memory at roughly one copy of the audio
+    (~230 MB per recorded hour) instead of two.
+
+    Returns (raw_path, {chunk_index: (start_sec, end_sec)}, total_seconds).
+    Chunks that fail to decode get no entry — the final chunk is an
+    intentionally empty blob and is expected to fail here.
+    """
+    raw_path = workdir / "concat.f32"
+    offsets: dict[int, tuple[float, float]] = {}
+    cursor = 0  # samples written so far
+
+    with raw_path.open("wb") as out:
+        for index, path in chunk_paths:
+            proc = subprocess.run(
+                [
+                    "ffmpeg", "-nostdin", "-v", "error", "-i", str(path),
+                    "-f", "f32le", "-ac", "1", "-ar", str(SAMPLE_RATE), "-",
+                ],
+                capture_output=True,
+            )
+            if proc.returncode != 0 or not proc.stdout:
+                detail = proc.stderr.decode(errors="replace").strip().splitlines()
+                LOGGER.info(
+                    "Chunk %d produced no audio (%s); its text will inherit the previous speaker.",
+                    index,
+                    (detail[-1][:120] if detail else "empty output"),
+                )
+                continue
+
+            out.write(proc.stdout)
+            n_samples = len(proc.stdout) // 4
+            offsets[index] = (
+                cursor / SAMPLE_RATE,
+                (cursor + n_samples) / SAMPLE_RATE,
+            )
+            cursor += n_samples
+
+    return raw_path, offsets, cursor / SAMPLE_RATE
+
+
+def _prune_minor_speakers(turns: list[SpeakerTurn]) -> list[SpeakerTurn]:
+    """
+    Fold away clusters that look like noise rather than participants.
+
+    Background noise, laughter and one-word interjections produce unreliable
+    embeddings, and each fragment tends to become its own "speaker". Without
+    this, noisy recordings invent a dozen speakers; with it, one threshold works
+    for both clean and noisy audio. Measured speaker counts (ground truth in
+    brackets) at threshold 0.6:
+
+        clean parliament debate [3-4]: 5 raw -> 3 pruned
+        noisy outdoor conversation [3]: 11 raw -> 4 pruned
+
+    A cluster survives if it holds a meaningful *share* of the speech OR enough
+    absolute speech — the second test matters in long meetings, where a genuine
+    but quiet participant is a tiny fraction of the total.
+    """
+    if not turns:
+        return turns
+
+    talk: dict[int, float] = {}
+    for turn in turns:
+        talk[turn.speaker] = talk.get(turn.speaker, 0.0) + (turn.end - turn.start)
+    total = sum(talk.values()) or 1.0
+
+    major = {
+        speaker
+        for speaker, seconds in talk.items()
+        if seconds / total >= settings.diarization_min_speaker_share
+        or seconds >= settings.diarization_min_speaker_seconds
+    }
+    if not major or len(major) == len(talk):
+        return turns
+
+    major_turns = [t for t in turns if t.speaker in major]
+    if not major_turns:
+        return turns
+
+    def nearest_major(turn: SpeakerTurn) -> int:
+        best, best_distance = turn.speaker, float("inf")
+        for other in major_turns:
+            if other.end >= turn.start and other.start <= turn.end:
+                return other.speaker  # overlapping: no closer answer exists
+            distance = min(abs(turn.start - other.end), abs(other.start - turn.end))
+            if distance < best_distance:
+                best, best_distance = other.speaker, distance
+        return best
+
+    LOGGER.info(
+        "Folding %d minor speaker cluster(s) into their nearest neighbour.",
+        len(talk) - len(major),
+    )
+    return [
+        t if t.speaker in major else SpeakerTurn(t.start, t.end, nearest_major(t))
+        for t in turns
+    ]
+
+
+def diarize_file(raw_path: Path) -> tuple[list[SpeakerTurn], int]:
+    """Diarize a raw float32 mono stream. Returns (turns, speaker_count)."""
+    samples = np.fromfile(raw_path, dtype=np.float32)
+    if samples.size == 0:
+        return [], 0
+
+    slot = _acquire_diarizer()
+    try:
+        result = slot.process(samples)
+    finally:
+        _release_diarizer(slot)
+
+    turns = [
+        SpeakerTurn(start=seg.start, end=seg.end, speaker=seg.speaker)
+        for seg in result.sort_by_start_time()
+    ]
+    turns = _prune_minor_speakers(turns)
+
+    # sherpa's speaker ids are arbitrary, and pruning leaves gaps; renumber by
+    # first appearance so "Speaker 1" is whoever spoke first.
+    order: dict[int, int] = {}
+    renumbered: list[SpeakerTurn] = []
+    for turn in turns:
+        if turn.speaker not in order:
+            order[turn.speaker] = len(order) + 1
+        renumbered.append(SpeakerTurn(turn.start, turn.end, order[turn.speaker]))
+
+    return renumbered, len(order)
+
+
+def _speaker_for(start: float, end: float, turns: list[SpeakerTurn]) -> int | None:
+    """The speaker whose turn overlaps [start, end] most, or None if none does."""
+    best_speaker: int | None = None
+    best_overlap = 0.0
+    for turn in turns:
+        if turn.end <= start:
+            continue
+        if turn.start >= end:
+            break  # turns are sorted by start time
+        overlap = min(end, turn.end) - max(start, turn.start)
+        if overlap > best_overlap:
+            best_speaker, best_overlap = turn.speaker, overlap
+    return best_speaker
+
+
+def label_transcript(
+    chunks: list[tuple[int, str | None, str | None]],
+    offsets: dict[int, tuple[float, float]],
+    turns: list[SpeakerTurn],
+) -> str:
+    """
+    Build a speaker-labelled transcript.
+
+    `chunks` is [(chunk_index, text, segments_json)] in index order. Every
+    chunk's words are preserved: a chunk with no timings or no decoded audio is
+    appended as a continuation of the current speaker rather than dropped.
+    """
+    blocks: list[tuple[int | None, list[str]]] = []
+
+    def append(speaker: int | None, text: str) -> None:
+        text = text.strip()
+        if not text:
+            return
+        if blocks and blocks[-1][0] == speaker:
+            blocks[-1][1].append(text)
+        else:
+            blocks.append((speaker, [text]))
+
+    for index, text, segments_json in chunks:
+        base = offsets.get(index, (None, None))[0]
+
+        segments: list[dict] = []
+        if segments_json:
+            try:
+                segments = json.loads(segments_json) or []
+            except (ValueError, TypeError):
+                segments = []
+
+        if base is None or not segments:
+            # No position or no timings: keep the words with the current speaker.
+            if text:
+                append(blocks[-1][0] if blocks else None, text)
+            continue
+
+        for seg in segments:
+            seg_text = (seg.get("text") or "").strip()
+            if not seg_text:
+                continue
+            start = base + float(seg.get("start") or 0.0)
+            end = base + float(seg.get("end") or 0.0)
+            speaker = _speaker_for(start, end, turns)
+            if speaker is None:
+                speaker = blocks[-1][0] if blocks else None
+            append(speaker, seg_text)
+
+    # Speech often starts before the first detected turn, which would open the
+    # transcript with "Unknown speaker". Attribute that lead-in to whoever the
+    # diarizer heard first instead.
+    first_known = next((s for s, _ in blocks if s is not None), None)
+    if first_known is not None:
+        for i, (speaker, parts) in enumerate(blocks):
+            if speaker is not None:
+                break
+            blocks[i] = (first_known, parts)
+
+    # Backfilling can leave neighbouring blocks with the same speaker.
+    coalesced: list[tuple[int | None, list[str]]] = []
+    for speaker, parts in blocks:
+        if coalesced and coalesced[-1][0] == speaker:
+            coalesced[-1][1].extend(parts)
+        else:
+            coalesced.append((speaker, list(parts)))
+
+    lines = []
+    for speaker, parts in coalesced:
+        label = f"Speaker {speaker}" if speaker is not None else "Unknown speaker"
+        lines.append(f"{label}: {' '.join(parts)}")
+    return "\n\n".join(lines)
+
+
+def diarize_meeting(
+    chunk_paths: list[tuple[int, Path]],
+    chunks: list[tuple[int, str | None, str | None]],
+) -> tuple[str, int, float] | None:
+    """
+    Full post-meeting pass.
+
+    Returns (labelled_transcript, speaker_count, audio_seconds), or None if
+    diarization could not run — in which case the caller keeps the plain
+    transcript, which is exactly the pre-diarization behaviour.
+    """
+    if not is_enabled():
+        return None
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="meetscribe-diar-") as tmp:
+            raw_path, offsets, total_seconds = decode_to_pcm(chunk_paths, Path(tmp))
+            if not offsets:
+                LOGGER.warning("No chunk decoded to audio; skipping diarization.")
+                return None
+
+            turns, speakers = diarize_file(raw_path)
+            if not turns:
+                LOGGER.warning("Diarization found no speech; keeping plain transcript.")
+                return None
+
+            labelled = label_transcript(chunks, offsets, turns)
+            LOGGER.info(
+                "🗣️  Diarization: %d speakers, %d turns over %.1fs of audio.",
+                speakers,
+                len(turns),
+                total_seconds,
+            )
+            return labelled, speakers, total_seconds
+    except Exception:
+        LOGGER.exception("Diarization failed; keeping plain transcript.")
+        return None

--- a/backend/app/diarization.py
+++ b/backend/app/diarization.py
@@ -81,7 +81,10 @@ def _build_diarizer():
     seg, emb = model_paths()
     config = so.OfflineSpeakerDiarizationConfig(
         segmentation=so.OfflineSpeakerSegmentationModelConfig(
-            pyannote=so.OfflineSpeakerSegmentationPyannoteModelConfig(model=str(seg)),
+            pyannote=so.OfflineSpeakerSegmentationPyannoteModelConfig(
+                model=str(seg),
+                window_shift_ratio=settings.diarization_window_shift_ratio,
+            ),
             num_threads=settings.diarization_threads,
         ),
         embedding=so.SpeakerEmbeddingExtractorConfig(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -306,6 +306,9 @@ def get_meeting(mid: uuid.UUID):
         data = mtg.model_dump()
         data["transcript_text"] = mtg.transcript_text if mtg.done else live_tx
         data["transcribed_chunks"] = transcribed_count
+        # Re-diarization needs the original audio, which older meetings may
+        # no longer have. A handful of stat() calls, single meeting only.
+        data["can_rediarize"] = bool(tasks.meeting_audio_chunks(db, mid))
 
         # Get existing feedback
         feedback_results = db.exec(
@@ -314,6 +317,43 @@ def get_meeting(mid: uuid.UUID):
         data["feedback"] = feedback_results
 
         return MeetingStatus(**data)
+
+
+@app.post("/api/meetings/{mid}/rediarize", status_code=202)
+def rediarize_meeting(mid: uuid.UUID):
+    """
+    Re-run transcription timings, diarization and the summary for a meeting.
+
+    For recordings made before speaker labels existed, and after changing the
+    diarization settings. Clearing `done` is what makes the UI poll and show
+    progress; the worker restores it even on failure.
+    """
+    with Session(engine) as db:
+        mtg = db.get(Meeting, mid)
+        if not mtg:
+            raise HTTPException(404, "Meeting not found")
+
+        if not tasks.meeting_audio_chunks(db, mid):
+            raise HTTPException(
+                409,
+                "The audio for this meeting is no longer on disk, so speakers "
+                "cannot be identified.",
+            )
+
+        if not mtg.done:
+            # Already being processed; don't start a second pass over it.
+            return {"ok": True, "already_running": True}
+
+        mtg.done = False
+        # Set so the status endpoint does not also queue a plain summary run.
+        mtg.summary_task_queued = True
+        mtg.processing_stage = "diarizing"
+        db.add(mtg)
+        db.commit()
+
+    _executor.submit(tasks.rediarize_meeting_in_worker, str(mid))
+    LOGGER.info("♻️  Queued re-diarization for meeting %s", mid)
+    return {"ok": True}
 
 
 @app.delete("/api/meetings/{mid}", status_code=204)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -302,13 +302,17 @@ def get_meeting(mid: uuid.UUID):
             db.add(mtg)
             db.commit()
 
-        live_tx = _build_live_transcript(db, mid)
         data = mtg.model_dump()
-        data["transcript_text"] = mtg.transcript_text if mtg.done else live_tx
+        # Only assemble the live transcript while it is still needed. A finished
+        # meeting used it nowhere, but paid for a scan of all its chunks on
+        # every single fetch.
+        data["transcript_text"] = (
+            mtg.transcript_text if mtg.done else _build_live_transcript(db, mid)
+        )
         data["transcribed_chunks"] = transcribed_count
-        # Re-diarization needs the original audio, which older meetings may
-        # no longer have. A handful of stat() calls, single meeting only.
-        data["can_rediarize"] = bool(tasks.meeting_audio_chunks(db, mid))
+        # Re-diarization needs the original audio, which older meetings may no
+        # longer have. Cheap existence check only — this runs on every poll.
+        data["can_rediarize"] = tasks.has_meeting_audio(db, mid)
 
         # Get existing feedback
         feedback_results = db.exec(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -33,6 +33,11 @@ class Meeting(SQLModel, table=True):
     summary_custom_language: str | None = None
     context: str | None = None
     timezone: str | None = None
+    # Which post-meeting stage is running: 'diarizing' | 'summarizing' | None.
+    # Drives the frontend's progress text; None once `done` is set.
+    processing_stage: str | None = None
+    # Distinct speakers found by diarization; None if it did not run.
+    speaker_count: int | None = None
 
 
 class MeetingChunk(SQLModel, table=True):
@@ -45,6 +50,13 @@ class MeetingChunk(SQLModel, table=True):
     chunk_index: int
     path: str
     text: Optional[str] = None
+    # Whisper's segment timings for this chunk, as JSON [{start,end,text}].
+    # Times are chunk-relative; diarization converts them to absolute using
+    # the offsets it measures when decoding the audio.
+    segments_json: Optional[str] = None
+    # True decoded length. Chunks are NOT reliably 30s, so this is the only
+    # trustworthy basis for absolute positions and meeting duration.
+    audio_seconds: Optional[float] = None
 
 
 class Feedback(SQLModel, table=True):
@@ -122,6 +134,10 @@ class MeetingStatus(SQLModel):
     summary_custom_language: str | None = None
     context: str | None = None
     timezone: str | None = None
+    processing_stage: str | None = None
+    speaker_count: int | None = None
+    # True when the original audio survives, so speakers can still be identified.
+    can_rediarize: bool = False
     feedback: list[str] = []  # List of submitted feedback types
 
 

--- a/backend/app/prompts.py
+++ b/backend/app/prompts.py
@@ -3,6 +3,28 @@
 #   {target_language}, {context_section}, {full_transcript}
 #   {date}, {duration}  — minutes mode only
 
+# ── Speaker labels ────────────────────────────────────────────────────────────
+# Appended to {context_section} when the transcript has been diarized, so the
+# model knows what the labels mean and how far to trust them.
+
+SPEAKER_NOTE = """
+<speaker_labels>
+This transcript is diarized: each block is prefixed with an anonymous speaker
+label (`Speaker 1`, `Speaker 2`, …) assigned automatically by voice. The labels
+are consistent within the transcript but contain no names.
+
+Use them to attribute decisions, questions, and action items to the right
+person. If someone's actual name or role becomes clear from the conversation —
+a self-introduction, or another speaker addressing them — you may use it, and
+say that it is inferred.
+
+The labels are imperfect: very short interjections are sometimes misattributed,
+and one person can occasionally appear under two labels. Prefer the reading that
+makes the conversation coherent, and do not invent speakers that the labels do
+not support.
+</speaker_labels>
+"""
+
 # ── Briefing ──────────────────────────────────────────────────────────────────
 # Pure executive digest. What was decided, what's at risk, what to do.
 

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -19,9 +19,13 @@ from sqlmodel import Session, select, func, create_engine
 from langdetect import detect, DetectorFactory
 from langdetect.lang_detect_exception import LangDetectException
 
+import json
+from dataclasses import dataclass, field
+
 from .config import settings
 from .models import Meeting, MeetingChunk
 from . import prompts as P
+from . import diarization
 
 LOGGER = logging.getLogger("meetscribe_tasks")
 
@@ -67,7 +71,30 @@ def get_whisper_model() -> WhisperModel:
     return _whisper_model_instance
 
 
-def transcribe_webm_chunk_in_worker(chunk_path_str: str) -> str:
+@dataclass
+class ChunkTranscription:
+    """Text plus per-segment timings, both chunk-relative."""
+
+    text: str
+    segments: list[dict] = field(default_factory=list)
+
+
+def _normalise_segments(raw) -> list[dict]:
+    """Coerce Groq/Whisper segment objects (dicts or attr objects) to plain dicts."""
+    out = []
+    for seg in raw or []:
+        get = seg.get if isinstance(seg, dict) else lambda k, d=None: getattr(seg, k, d)
+        text = (get("text") or "").strip()
+        if not text:
+            continue
+        try:
+            out.append({"start": float(get("start") or 0.0), "end": float(get("end") or 0.0), "text": text})
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def transcribe_webm_chunk_in_worker(chunk_path_str: str) -> ChunkTranscription:
     """Transcribes an audio chunk using either a cloud API (Groq) or a local model."""
     chunk_path = Path(chunk_path_str)
     try:
@@ -103,7 +130,13 @@ def transcribe_webm_chunk_in_worker(chunk_path_str: str) -> str:
                         response_format="verbose_json",
                     )
                 LOGGER.info("Cloud transcription succeeded for %s", path_to_transcribe.name)
-                return resp.text.strip()
+                # verbose_json carries segments, but the SDK only types `text`,
+                # so read them from the model's extra fields.
+                extra = getattr(resp, "model_extra", None) or {}
+                raw_segments = getattr(resp, "segments", None) or extra.get("segments")
+                return ChunkTranscription(
+                    text=resp.text.strip(), segments=_normalise_segments(raw_segments)
+                )
             finally:
                 if output_flac_path and output_flac_path.exists():
                     output_flac_path.unlink()
@@ -117,10 +150,17 @@ def transcribe_webm_chunk_in_worker(chunk_path_str: str) -> str:
                     threshold=0.1, min_silence_duration_ms=500, speech_pad_ms=300
                 ),
             )
-            return " ".join(s.text for s in segments).strip()
+            segment_list = list(segments)
+            # Text is joined exactly as before, so switching diarization on
+            # cannot change the words themselves.
+            return ChunkTranscription(
+                text=" ".join(s.text for s in segment_list).strip(),
+                segments=_normalise_segments(segment_list),
+            )
     except Exception as e:
         LOGGER.error("Failed to transcribe %s: %s", chunk_path.name, e, exc_info=True)
-        return ""
+        # Must be a ChunkTranscription, not "": callers read .text off it.
+        return ChunkTranscription(text="")
 
 
 def generate_title_for_meeting(summary: str, full_transcript: str) -> str:
@@ -186,6 +226,18 @@ def detect_language_local(text_snippet: str) -> str:
         return "English"
 
 
+_SPEAKER_LINE = re.compile(r"^Speaker \d+:", re.MULTILINE)
+
+
+def looks_diarized(transcript: str) -> bool:
+    """True if the transcript carries speaker labels.
+
+    Derived from the text itself so regenerating a summary from a stored
+    transcript keeps the speaker guidance without extra bookkeeping.
+    """
+    return bool(transcript) and bool(_SPEAKER_LINE.search(transcript))
+
+
 def summarise_transcript_in_worker(
     full_transcript: str,
     summary_length: str,
@@ -208,8 +260,14 @@ def summarise_transcript_in_worker(
             target_language = detected_language
 
         context_section = ""
+        if looks_diarized(full_transcript):
+            # Kept in the instruction section rather than inside the transcript
+            # block, so every summary template picks it up unchanged.
+            context_section += P.SPEAKER_NOTE
         if context and context.strip():
-            context_section = f"""
+            # `+=` not `=`: a plain assignment here discarded the speaker note
+            # whenever the user had supplied context.
+            context_section += f"""
 <user_provided_context>
 Critical context from the user — use as source of truth for names, projects, and technical terms.
 ---
@@ -236,6 +294,17 @@ Critical context from the user — use as source of truth for names, projects, a
             full_transcript=full_transcript,
             date=date_str,
             duration=duration_str,
+        )
+
+        # Restate the target language after the transcript. The instruction at
+        # the top of the template is a long way from where generation starts,
+        # and has been observed to drift (a German transcript summarised in
+        # Polish). This also covers the briefing template, which never
+        # interpolated {target_language} at all.
+        prompt += (
+            f"\n\n---\n\nWrite the entire summary in {target_language}, "
+            "regardless of the language of the transcript. Quotations may stay "
+            "in their original language."
         )
 
         response = _anthropic_client.messages.create(
@@ -265,12 +334,48 @@ def rebuild_full_transcript(
 
 def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
     LOGGER.info("Meeting %s: Finalizing. Building transcript and summarizing.", mtg.id)
-    final_transcript, num_chunks = rebuild_full_transcript(db, mtg.id)
+    plain_transcript, num_chunks = rebuild_full_transcript(db, mtg.id)
+
+    # Word count comes from the unlabelled text so the number stays comparable
+    # with meetings recorded before diarization existed.
+    word_count = len(plain_transcript.split()) if plain_transcript else 0
+
+    final_transcript = plain_transcript
+    duration_seconds = num_chunks * 30
+
+    if plain_transcript and diarization.is_enabled():
+        mtg.processing_stage = "diarizing"
+        db.add(mtg)
+        db.commit()  # publish the stage before a multi-minute job
+
+        chunk_rows = db.exec(
+            select(
+                MeetingChunk.chunk_index, MeetingChunk.text,
+                MeetingChunk.segments_json, MeetingChunk.path,
+            )
+            .where(MeetingChunk.meeting_id == mtg.id)
+            .order_by(MeetingChunk.chunk_index)
+        ).all()
+
+        result = diarization.diarize_meeting(
+            [(r.chunk_index, Path(r.path)) for r in chunk_rows if r.path],
+            [(r.chunk_index, r.text, r.segments_json) for r in chunk_rows],
+        )
+        if result:
+            final_transcript, speakers, audio_seconds = result
+            mtg.speaker_count = speakers
+            # Real decoded length; chunk_count * 30 is only a guess.
+            duration_seconds = int(round(audio_seconds))
+
     mtg.transcript_text = final_transcript
 
     if final_transcript:
-        mtg.word_count = len(final_transcript.split())
-        mtg.duration_seconds = num_chunks * 30
+        mtg.word_count = word_count
+        mtg.duration_seconds = duration_seconds
+
+        mtg.processing_stage = "summarizing"
+        db.add(mtg)
+        db.commit()
 
         summary_md = summarise_transcript_in_worker(
             final_transcript,
@@ -279,7 +384,7 @@ def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
             mtg.summary_custom_language,
             mtg.context,
             meeting_date=mtg.started_at.strftime("%Y-%m-%d") if mtg.started_at else None,
-            duration_seconds=num_chunks * 30,
+            duration_seconds=duration_seconds,
         )
         mtg.summary_markdown = summary_md
 
@@ -298,9 +403,116 @@ def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
         mtg.duration_seconds = 0
         mtg.summary_markdown = "Error: Transcript was empty, summary could not be generated."
 
+    mtg.processing_stage = None
     mtg.done = True
     db.add(mtg)
     db.commit()
+
+
+def meeting_audio_chunks(db: Session, meeting_id: uuid.UUID) -> list[MeetingChunk]:
+    """
+    Chunks whose audio is still on disk. Audio is only removed when a meeting is
+    deleted, but meetings recorded before retention existed may have none — and
+    without audio there is nothing to diarize.
+    """
+    chunks = db.exec(
+        select(MeetingChunk)
+        .where(MeetingChunk.meeting_id == meeting_id)
+        .order_by(MeetingChunk.chunk_index)
+    ).all()
+
+    available = []
+    for chunk in chunks:
+        if not chunk.path:
+            continue
+        try:
+            path = Path(chunk.path)
+            # The final chunk is an empty signalling blob; ignore those.
+            if path.exists() and path.stat().st_size > 100:
+                available.append(chunk)
+        except OSError:
+            continue
+    return available
+
+
+def rediarize_meeting_in_worker(meeting_id_str: str, retranscribe: bool = True) -> None:
+    """
+    Re-run diarization and the summary for a meeting that already finished.
+
+    Used for recordings made before speaker labels existed, and after changing
+    the diarization settings. Meetings from before `segments_json` existed have
+    no timings to merge against, so their chunks are transcribed again first.
+    """
+    engine = get_db_engine()
+    meeting_id = uuid.UUID(meeting_id_str)
+
+    try:
+        with Session(engine) as db:
+            mtg = db.get(Meeting, meeting_id)
+            if not mtg:
+                LOGGER.error("Meeting %s not found for re-diarization.", meeting_id_str)
+                return
+
+            chunks = meeting_audio_chunks(db, meeting_id)
+            if not chunks:
+                LOGGER.error(
+                    "Meeting %s has no audio on disk; cannot re-diarize.", meeting_id_str
+                )
+                mtg.processing_stage = None
+                mtg.done = True
+                db.add(mtg)
+                db.commit()
+                return
+
+            if retranscribe:
+                missing = [c for c in chunks if not c.segments_json]
+                if missing:
+                    LOGGER.info(
+                        "♻️  Meeting %s: rebuilding timings for %d chunk(s).",
+                        meeting_id_str, len(missing),
+                    )
+                    mtg.processing_stage = "transcribing"
+                    db.add(mtg)
+                    db.commit()
+
+                    for chunk in missing:
+                        try:
+                            result = transcribe_webm_chunk_in_worker(chunk.path)
+                        except Exception as exc:
+                            LOGGER.warning(
+                                "Chunk %d could not be re-transcribed: %s",
+                                chunk.chunk_index, exc,
+                            )
+                            continue
+                        if not result.segments:
+                            continue
+                        chunk.segments_json = json.dumps(result.segments)
+                        # Store the matching text too, so words and timings can
+                        # never come from different transcription runs.
+                        if result.text:
+                            chunk.text = result.text
+                        db.add(chunk)
+                    db.commit()
+
+            LOGGER.info("♻️  Meeting %s: re-running diarization and summary.", meeting_id_str)
+            mtg.done = False
+            mtg.summary_task_queued = False
+            finalize_meeting_processing(db, mtg)
+            LOGGER.info("✅ Meeting %s re-diarized.", meeting_id_str)
+
+    except Exception:
+        LOGGER.exception("Re-diarization failed for %s.", meeting_id_str)
+        # Never leave the meeting stuck un-done, or the UI polls forever.
+        try:
+            with Session(engine) as db:
+                mtg = db.get(Meeting, meeting_id)
+                if mtg and not mtg.done:
+                    mtg.processing_stage = None
+                    mtg.done = True
+                    db.add(mtg)
+                    db.commit()
+        except Exception:
+            LOGGER.exception("Could not restore state for %s.", meeting_id_str)
 
 
 def backup_database() -> None:
@@ -436,7 +648,7 @@ def process_transcription_and_summary(
 
     for attempt in range(3):
         try:
-            chunk_text = transcribe_webm_chunk_in_worker(chunk_path_str)
+            transcription = transcribe_webm_chunk_in_worker(chunk_path_str)
             with Session(engine) as db:
                 mc = db.exec(
                     select(MeetingChunk).where(
@@ -450,7 +662,10 @@ def process_transcription_and_summary(
                         meeting_id_str, chunk_index,
                     )
                     return
-                mc.text = chunk_text
+                mc.text = transcription.text
+                mc.segments_json = (
+                    json.dumps(transcription.segments) if transcription.segments else None
+                )
                 db.add(mc)
                 db.commit()
 

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import datetime as dt
 import uuid
 import time
@@ -433,6 +434,34 @@ def meeting_audio_chunks(db: Session, meeting_id: uuid.UUID) -> list[MeetingChun
         except OSError:
             continue
     return available
+
+
+def has_meeting_audio(db: Session, meeting_id: uuid.UUID) -> bool:
+    """
+    Whether any chunk audio survives, without paying for the full list.
+
+    Called on every meeting fetch (including polls), so it must stay cheap:
+    one query for a single chunk path, then one directory scan that stops at
+    the first usable file. Statting every chunk cost ~100ms on a 721-chunk
+    meeting locally, and far more over a bind mount.
+    """
+    first = db.exec(
+        select(MeetingChunk.path)
+        .where(MeetingChunk.meeting_id == meeting_id)
+        .where(MeetingChunk.path.is_not(None))
+        .limit(1)
+    ).first()
+    if not first:
+        return False
+
+    try:
+        with os.scandir(Path(first).parent) as entries:
+            for entry in entries:
+                if entry.name.endswith(".webm") and entry.stat().st_size > 100:
+                    return True
+    except OSError:
+        return False
+    return False
 
 
 def rediarize_meeting_in_worker(meeting_id_str: str, retranscribe: bool = True) -> None:

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -3,6 +3,10 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
+# Fetch local diarization models if absent. Idempotent, and non-fatal: without
+# them the app simply produces transcripts without speaker labels.
+python /app/utils/fetch_diarization_models.py
+
 # Run all database migrations. These scripts are idempotent and safe to run
 # on every application start, for both the web server and the worker.
 python /app/utils/run_migrations.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,8 @@ groq==0.26.0
 
 # Language detection
 langdetect==1.0.9
+
+# Speaker diarization (local, CPU). ONNX/int8 — no PyTorch, and it reuses the
+# onnxruntime that faster-whisper already pulls in.
+sherpa-onnx==1.13.6
+numpy

--- a/backend/utils/add_diarization_columns.py
+++ b/backend/utils/add_diarization_columns.py
@@ -1,0 +1,61 @@
+"""
+utils/add_diarization_columns.py
+────────────────────────────────────────────────────────
+Adds the columns speaker diarization needs:
+
+  meeting.processing_stage   — which post-meeting stage is running
+  meeting.speaker_count      — distinct speakers found
+  meetingchunk.segments_json — whisper segment timings for the chunk
+  meetingchunk.audio_seconds — true decoded chunk length
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+# --- Locate backend package ---
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from migration_helper import ensure_database_exists
+from sqlalchemy import text
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+log = logging.getLogger("migration")
+
+COLUMNS = [
+    ("meeting", "processing_stage", "TEXT"),
+    ("meeting", "speaker_count", "INTEGER"),
+    ("meetingchunk", "segments_json", "TEXT"),
+    ("meetingchunk", "audio_seconds", "REAL"),
+]
+
+
+def run_migration():
+    db_path, engine = ensure_database_exists()
+
+    with engine.connect() as connection:
+        with connection.begin():
+            try:
+                for table, column, coltype in COLUMNS:
+                    result = connection.execute(text(f"PRAGMA table_info({table});"))
+                    existing = [row[1] for row in result]
+                    if not existing:
+                        log.info("Table `%s` does not exist yet; skipping.", table)
+                        continue
+                    if column in existing:
+                        log.info("`%s.%s` already exists.", table, column)
+                        continue
+                    log.info("Adding `%s` column to `%s` table...", column, table)
+                    connection.execute(
+                        text(f"ALTER TABLE {table} ADD COLUMN {column} {coltype};")
+                    )
+
+                log.info("Migration successful.")
+            except Exception as e:
+                log.error("An error occurred during migration: %s", e, exc_info=True)
+
+
+if __name__ == "__main__":
+    run_migration()

--- a/backend/utils/add_meeting_id_indexes.py
+++ b/backend/utils/add_meeting_id_indexes.py
@@ -1,0 +1,76 @@
+"""
+utils/add_meeting_id_indexes.py
+────────────────────────────────────────────────────────
+Indexes the `meeting_id` foreign keys.
+
+Without these, every per-meeting query is a full table scan. `meetingchunk`
+had no index at all, and loading one meeting runs several such queries (live
+transcript assembly, transcribed-chunk count, audio availability), so opening
+a meeting got slower as the table grew — 23k chunk rows scanned repeatedly.
+
+Idempotent: CREATE INDEX IF NOT EXISTS.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+# --- Locate backend package ---
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from migration_helper import ensure_database_exists
+from sqlalchemy import text
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+log = logging.getLogger("migration")
+
+INDEXES = [
+    ("ix_meetingchunk_meeting_id", "meetingchunk", "meeting_id"),
+    ("ix_feedback_meeting_id", "feedback", "meeting_id"),
+    ("ix_meetingsection_meeting_id", "meetingsection", "meeting_id"),
+]
+
+
+def run_migration():
+    db_path, engine = ensure_database_exists()
+
+    with engine.connect() as connection:
+        with connection.begin():
+            try:
+                for index_name, table, column in INDEXES:
+                    exists = connection.execute(
+                        text(
+                            "SELECT name FROM sqlite_master "
+                            "WHERE type='table' AND name=:table"
+                        ),
+                        {"table": table},
+                    ).first()
+                    if not exists:
+                        log.info("Table `%s` does not exist yet; skipping.", table)
+                        continue
+
+                    columns = [
+                        row[1]
+                        for row in connection.execute(text(f"PRAGMA table_info({table});"))
+                    ]
+                    if column not in columns:
+                        log.info("`%s.%s` does not exist; skipping.", table, column)
+                        continue
+
+                    log.info("Ensuring index %s on %s(%s)…", index_name, table, column)
+                    connection.execute(
+                        text(
+                            f"CREATE INDEX IF NOT EXISTS {index_name} "
+                            f"ON {table} ({column});"
+                        )
+                    )
+
+                log.info("Migration successful.")
+            except Exception as e:
+                log.error("An error occurred during migration: %s", e, exc_info=True)
+
+
+if __name__ == "__main__":
+    run_migration()

--- a/backend/utils/fetch_diarization_models.py
+++ b/backend/utils/fetch_diarization_models.py
@@ -1,0 +1,105 @@
+"""
+utils/fetch_diarization_models.py
+────────────────────────────────────────────────────────
+Downloads the local speaker-diarization models, if they are not already there.
+
+Idempotent and safe to run on every start: it skips files that exist and
+non-zero-length. Uses only the standard library, so it can run before any
+application dependency is importable.
+
+Models (~36 MB total, ONNX/int8, no PyTorch):
+  * sherpa-onnx-pyannote-segmentation-3-0 — speech/speaker segmentation
+  * wespeaker_en_voxceleb_CAM++           — speaker embeddings
+
+Target directory comes from DIARIZATION_MODEL_DIR, defaulting to the same
+`backend/data/models` the application config uses.
+"""
+
+import os
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_DIR = BASE_DIR / "data" / "models"
+
+RELEASES = "https://github.com/k2-fsa/sherpa-onnx/releases/download"
+SEGMENTATION_ARCHIVE = (
+    f"{RELEASES}/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
+)
+# The upstream release tag really is spelled "recongition".
+EMBEDDING_URL = f"{RELEASES}/speaker-recongition-models/wespeaker_en_voxceleb_CAM%2B%2B.onnx"
+
+SEGMENTATION_DIR = "sherpa-onnx-pyannote-segmentation-3-0"
+SEGMENTATION_FILE = "model.int8.onnx"
+EMBEDDING_FILE = "wespeaker_en_voxceleb_CAM++.onnx"
+
+
+def _present(path: Path) -> bool:
+    return path.exists() and path.stat().st_size > 0
+
+
+def _download(url: str, dest: Path) -> None:
+    print(f"[models] downloading {url}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        with urllib.request.urlopen(url, timeout=120) as response, tmp.open("wb") as out:
+            while True:
+                block = response.read(1 << 20)
+                if not block:
+                    break
+                out.write(block)
+    except urllib.error.URLError as exc:
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(f"could not download {url}: {exc}") from exc
+    # Rename only once complete, so an interrupted run cannot leave a truncated
+    # model that later looks present.
+    tmp.replace(dest)
+    print(f"[models] saved {dest.name} ({dest.stat().st_size / 1e6:.1f} MB)")
+
+
+def fetch(target_dir: Path) -> None:
+    seg_model = target_dir / SEGMENTATION_DIR / SEGMENTATION_FILE
+    emb_model = target_dir / EMBEDDING_FILE
+
+    if _present(seg_model):
+        print(f"[models] {SEGMENTATION_DIR}/{SEGMENTATION_FILE} already present")
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "segmentation.tar.bz2"
+            _download(SEGMENTATION_ARCHIVE, archive)
+            print("[models] extracting segmentation model")
+            with tarfile.open(archive, "r:bz2") as tar:
+                # filter="data" refuses absolute paths and traversal.
+                tar.extractall(path=target_dir, filter="data")
+        if not _present(seg_model):
+            raise RuntimeError(f"archive did not contain {seg_model}")
+
+    if _present(emb_model):
+        print(f"[models] {EMBEDDING_FILE} already present")
+    else:
+        _download(EMBEDDING_URL, emb_model)
+
+
+def main() -> int:
+    target_dir = Path(os.environ.get("DIARIZATION_MODEL_DIR") or DEFAULT_DIR)
+    try:
+        fetch(target_dir)
+    except Exception as exc:
+        # Never fatal: without models the app simply skips speaker labels.
+        print(f"[models] WARNING: {exc}", file=sys.stderr)
+        print(
+            "[models] Diarization will be skipped until the models are available.",
+            file=sys.stderr,
+        )
+        return 0
+    print(f"[models] diarization models ready in {target_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/utils/fetch_diarization_models.py
+++ b/backend/utils/fetch_diarization_models.py
@@ -30,12 +30,24 @@ RELEASES = "https://github.com/k2-fsa/sherpa-onnx/releases/download"
 SEGMENTATION_ARCHIVE = (
     f"{RELEASES}/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
 )
-# The upstream release tag really is spelled "recongition".
-EMBEDDING_URL = f"{RELEASES}/speaker-recongition-models/wespeaker_en_voxceleb_CAM%2B%2B.onnx"
-
 SEGMENTATION_DIR = "sherpa-onnx-pyannote-segmentation-3-0"
 SEGMENTATION_FILE = "model.int8.onnx"
-EMBEDDING_FILE = "wespeaker_en_voxceleb_CAM++.onnx"
+
+# Whichever embedder is configured gets downloaded. The upstream release tag
+# really is spelled "recongition". Benchmarked mean DER over four AMI meetings
+# is noted beside each; campplus is the default and the best of them.
+EMBEDDING_MODELS = {
+    "3dspeaker_speech_campplus_sv_zh-cn_16k-common.onnx": 23.7,
+    "3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx": 25.7,
+    "wespeaker_en_voxceleb_CAM++.onnx": 60.7,
+    "nemo_en_titanet_small.onnx": None,
+}
+DEFAULT_EMBEDDING_FILE = "3dspeaker_speech_campplus_sv_zh-cn_16k-common.onnx"
+
+
+def embedding_url(filename: str) -> str:
+    # '+' must be percent-encoded or GitHub serves a 404.
+    return f"{RELEASES}/speaker-recongition-models/{filename.replace('+', '%2B')}"
 
 
 def _present(path: Path) -> bool:
@@ -62,9 +74,9 @@ def _download(url: str, dest: Path) -> None:
     print(f"[models] saved {dest.name} ({dest.stat().st_size / 1e6:.1f} MB)")
 
 
-def fetch(target_dir: Path) -> None:
+def fetch(target_dir: Path, embedding_file: str = DEFAULT_EMBEDDING_FILE) -> None:
     seg_model = target_dir / SEGMENTATION_DIR / SEGMENTATION_FILE
-    emb_model = target_dir / EMBEDDING_FILE
+    emb_model = target_dir / embedding_file
 
     if _present(seg_model):
         print(f"[models] {SEGMENTATION_DIR}/{SEGMENTATION_FILE} already present")
@@ -80,15 +92,24 @@ def fetch(target_dir: Path) -> None:
             raise RuntimeError(f"archive did not contain {seg_model}")
 
     if _present(emb_model):
-        print(f"[models] {EMBEDDING_FILE} already present")
+        print(f"[models] {embedding_file} already present")
     else:
-        _download(EMBEDDING_URL, emb_model)
+        _download(embedding_url(embedding_file), emb_model)
 
 
 def main() -> int:
     target_dir = Path(os.environ.get("DIARIZATION_MODEL_DIR") or DEFAULT_DIR)
+    embedding_file = (
+        os.environ.get("DIARIZATION_EMBEDDING_MODEL") or DEFAULT_EMBEDDING_FILE
+    )
+    if embedding_file not in EMBEDDING_MODELS:
+        print(
+            f"[models] note: {embedding_file} is not one of the benchmarked models; "
+            "attempting the download anyway.",
+            file=sys.stderr,
+        )
     try:
-        fetch(target_dir)
+        fetch(target_dir, embedding_file)
     except Exception as exc:
         # Never fatal: without models the app simply skips speaker labels.
         print(f"[models] WARNING: {exc}", file=sys.stderr)

--- a/backend/utils/rediarize_meeting.py
+++ b/backend/utils/rediarize_meeting.py
@@ -1,0 +1,134 @@
+"""
+utils/rediarize_meeting.py
+────────────────────────────────────────────────────────
+Command-line counterpart to the "re-run with speaker labels" button, for
+backfilling meetings in bulk.
+
+Both call the same worker (`tasks.rediarize_meeting_in_worker`), so the result
+is identical to a freshly recorded meeting.
+
+Two prerequisites, checked per meeting:
+
+  * the chunk audio must still be on disk (it is deleted only when the meeting
+    is deleted, but older meetings may predate retention)
+  * each chunk needs Whisper segment timings. Meetings from before that column
+    existed have none, so their audio is transcribed again first — that costs
+    API calls when RECOGNITION_IN_CLOUD is true.
+
+Usage (from the backend/ directory):
+
+    python utils/rediarize_meeting.py --list
+    python utils/rediarize_meeting.py <id-or-prefix> [...]
+    python utils/rediarize_meeting.py --all-with-audio
+"""
+
+import argparse
+import logging
+import sys
+import uuid
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from sqlmodel import Session, create_engine, select
+
+from app.config import settings
+from app.models import Meeting
+from app import tasks
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+log = logging.getLogger("rediarize")
+
+
+def make_engine():
+    return create_engine(f"sqlite:///{settings.db_path}", echo=False)
+
+
+def describe(db: Session, mtg: Meeting) -> str:
+    chunks = tasks.meeting_audio_chunks(db, mtg.id)
+    with_timings = sum(1 for c in chunks if c.segments_json)
+    return (
+        f"{str(mtg.id)[:8]}  audio={len(chunks):3d}  timings={with_timings:3d}  "
+        f"speakers={mtg.speaker_count!s:>4}  {(mtg.title or '')[:44]}"
+    )
+
+
+def candidates(db: Session) -> list[Meeting]:
+    meetings = db.exec(select(Meeting).order_by(Meeting.started_at.desc())).all()
+    return [m for m in meetings if tasks.meeting_audio_chunks(db, m.id)]
+
+
+def resolve(db: Session, token: str) -> Meeting | None:
+    wanted = token.replace("-", "").lower()
+    for mtg in db.exec(select(Meeting)).all():
+        if str(mtg.id).replace("-", "").lower().startswith(wanted):
+            return mtg
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-run diarization and summary for existing meetings."
+    )
+    parser.add_argument("ids", nargs="*", help="meeting ids or unique prefixes")
+    parser.add_argument("--list", action="store_true", help="show what can be re-diarized")
+    parser.add_argument(
+        "--all-with-audio", action="store_true", help="every meeting whose audio survives"
+    )
+    parser.add_argument(
+        "--no-retranscribe",
+        action="store_true",
+        help="skip rebuilding missing timings (meetings without them are then skipped)",
+    )
+    args = parser.parse_args()
+
+    engine = make_engine()
+
+    with Session(engine) as db:
+        if args.list:
+            rows = candidates(db)
+            total = len(db.exec(select(Meeting)).all())
+            print(f"{len(rows)} of {total} meetings still have audio and can be re-diarized:\n")
+            for mtg in rows:
+                print("  " + describe(db, mtg))
+            if not rows:
+                print("  (none)")
+            return 0
+
+        targets: list[uuid.UUID] = []
+        for token in args.ids:
+            mtg = resolve(db, token)
+            if not mtg:
+                log.error("No meeting matching %r", token)
+                return 1
+            targets.append(mtg.id)
+
+        if args.all_with_audio:
+            targets += [m.id for m in candidates(db) if m.id not in targets]
+
+        if not targets:
+            parser.print_help()
+            return 1
+
+        for mid in targets:
+            mtg = db.get(Meeting, mid)
+            log.info("=== %s", describe(db, mtg))
+
+    # Outside the session: the worker opens its own.
+    for mid in targets:
+        tasks.rediarize_meeting_in_worker(str(mid), retranscribe=not args.no_retranscribe)
+        with Session(engine) as db:
+            mtg = db.get(Meeting, mid)
+            log.info(
+                "  -> speakers=%s duration=%ss words=%s",
+                mtg.speaker_count, mtg.duration_seconds, mtg.word_count,
+            )
+
+    log.info("Finished %d meeting(s).", len(targets))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/utils/run_migrations.py
+++ b/backend/utils/run_migrations.py
@@ -29,6 +29,7 @@ MIGRATIONS = [
     "add_timezone_column.py",
     "add_meeting_sections_table.py",
     "add_enhanced_section_columns.py",
+    "add_diarization_columns.py",
 ]
 
 

--- a/backend/utils/run_migrations.py
+++ b/backend/utils/run_migrations.py
@@ -30,6 +30,7 @@ MIGRATIONS = [
     "add_meeting_sections_table.py",
     "add_enhanced_section_columns.py",
     "add_diarization_columns.py",
+    "add_meeting_id_indexes.py",
 ]
 
 

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -99,6 +99,15 @@ export const CheckIcon: React.FC<IconProps> = ({ size = 14 }) => (
 	</svg>
 )
 
+export const SpeakersIcon: React.FC<IconProps> = ({ size = 14 }) => (
+	<svg {...iconProps(size)}>
+		<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+		<circle cx="9" cy="7" r="4" />
+		<path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+		<path d="M16 3.13a4 4 0 0 1 0 7.75" />
+	</svg>
+)
+
 export const CloseIcon: React.FC<IconProps> = ({ size = 14 }) => (
 	<svg {...iconProps(size)}>
 		<line x1="18" y1="6" x2="6" y2="18" />

--- a/frontend/src/components/RecordingStatus.tsx
+++ b/frontend/src/components/RecordingStatus.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Spinner from './Spinner'
 import { AppTheme } from '../styles/theme'
 import { AudioSource } from '../types'
 
@@ -17,6 +18,8 @@ interface RecordingStatusProps {
 	audioSource: AudioSource
 	wakeLockStatus: 'inactive' | 'active' | 'error'
 	isPaused: boolean
+	/** Backend post-meeting stage: 'diarizing' | 'summarizing' | null. */
+	processingStage: string | null
 }
 
 const formatTime = (seconds: number) => {
@@ -40,8 +43,17 @@ const RecordingStatus: React.FC<RecordingStatusProps> = ({
 	audioSource,
 	wakeLockStatus,
 	isPaused,
+	processingStage,
 }) => {
 	const realTotal = expectedTotalChunks !== null ? expectedTotalChunks : localChunksCount
+	// Diarization runs over the whole recording and can take minutes, so say
+	// which stage is running rather than a bare "please wait".
+	const processingLabel =
+		processingStage === 'diarizing'
+			? 'Identifying speakers…'
+			: processingStage === 'summarizing'
+				? 'Writing summary…'
+				: 'Processing… Please wait.'
 	const getUploadProgressPercentage = () => (realTotal === 0 ? 0 : Math.min(100, (uploadedChunks / realTotal) * 100))
 	const getTranscriptionProgressPercentage = () => (realTotal === 0 ? 0 : Math.min(100, (transcribedChunks / realTotal) * 100))
 	const allChunksUploaded = realTotal > 0 && uploadedChunks >= realTotal
@@ -178,7 +190,20 @@ const RecordingStatus: React.FC<RecordingStatusProps> = ({
 						color: isRecording ? (isPaused ? '#f59e0b' : theme.button.danger) : isProcessing ? theme.secondaryText : theme.button.primary,
 						marginBottom: '4px',
 					}}>
-					{isRecording ? (isPaused ? '⏸ Paused' : '🔴 Recording...') : isProcessing ? 'Processing... Please wait.' : 'Ready'}
+					{isRecording ? (
+						isPaused ? (
+							'⏸ Paused'
+						) : (
+							'🔴 Recording...'
+						)
+					) : isProcessing ? (
+						<span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+							<Spinner size={18} label={processingLabel} />
+							{processingLabel}
+						</span>
+					) : (
+						'Ready'
+					)}
 				</div>
 			</div>
 

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+interface SpinnerProps {
+	/** Diameter in px. */
+	size?: number
+	/** Defaults to the surrounding text colour. */
+	color?: string
+	/** Announced to screen readers; omit for purely decorative use. */
+	label?: string
+}
+
+/**
+ * Small indeterminate spinner for waits with no meaningful percentage.
+ * The rotation lives in index.css (.spinner) so it respects
+ * prefers-reduced-motion.
+ */
+const Spinner: React.FC<SpinnerProps> = ({ size = 16, color = 'currentColor', label }) => (
+	<svg
+		className="spinner"
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		role={label ? 'status' : undefined}
+		aria-label={label}
+		aria-hidden={label ? undefined : true}
+		style={{ display: 'inline-block', verticalAlign: '-0.15em', flexShrink: 0 }}>
+		<circle cx="12" cy="12" r="9" stroke={color} strokeWidth="2.5" strokeOpacity="0.25" />
+		<path d="M21 12a9 9 0 0 0-9-9" stroke={color} strokeWidth="2.5" strokeLinecap="round" />
+	</svg>
+)
+
+export default Spinner

--- a/frontend/src/hooks/useMeetingSummary.ts
+++ b/frontend/src/hooks/useMeetingSummary.ts
@@ -133,6 +133,34 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 		}
 	}, [mid, fetchMeetingData])
 
+	/**
+	 * Switch the summary language. The backend clears `done` so progress can be
+	 * polled, but polling only starts once a fetch observes that — without the
+	 * re-fetch below the page sat on a stale summary until a manual refresh.
+	 */
+	const handleTranslate = useCallback(
+		async (targetLanguage: string, languageMode: string) => {
+			if (!mid) return
+			setIsRegenerating(true)
+			setError(null)
+			try {
+				const res = await fetch(apiUrl(`/api/meetings/${mid}/translate`), {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ target_language: targetLanguage, language_mode: languageMode }),
+				})
+				if (!res.ok) throw new Error('Could not start translation.')
+				setIsProcessing(true)
+				fetchMeetingData(false)
+			} catch (err) {
+				setError(err instanceof Error ? err.message : 'Could not start translation.')
+			} finally {
+				setIsRegenerating(false)
+			}
+		},
+		[mid, fetchMeetingData],
+	)
+
 	const handleFeedbackToggle = async (type: string, isSelected: boolean) => {
 		if (!mid) return
 		setSubmittedFeedback((prev) => (isSelected ? [...prev, type] : prev.filter((t) => t !== type)))
@@ -277,6 +305,7 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 		speakerCount,
 		processingStage,
 		handleRediarize,
+		handleTranslate,
 		handleFeedbackToggle,
 		handleSuggestionSubmit,
 		handleRegenerate,

--- a/frontend/src/hooks/useMeetingSummary.ts
+++ b/frontend/src/hooks/useMeetingSummary.ts
@@ -25,6 +25,10 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 	const [currentMeetingLength, setCurrentMeetingLength] = useState<SummaryLength>('narrative')
 	const [submittedFeedback, setSubmittedFeedback] = useState<string[]>([])
 	const [isRegenerating, setIsRegenerating] = useState(false)
+	// Whether the original audio survives, so speakers can still be identified.
+	const [canRediarize, setCanRediarize] = useState(false)
+	const [speakerCount, setSpeakerCount] = useState<number | null>(null)
+	const [processingStage, setProcessingStage] = useState<string | null>(null)
 
 	const fetchMeetingData = useCallback(
 		async (isInitialFetch: boolean = false) => {
@@ -54,6 +58,9 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 				}
 
 				setContext(data.context || '')
+				setCanRediarize(!!data.can_rediarize)
+				setSpeakerCount(typeof data.speaker_count === 'number' ? data.speaker_count : null)
+				setProcessingStage(data.processing_stage ?? null)
 				const trn = data.transcript_text || null
 				setTranscript(trn)
 				setSummaryMarkdown(data.summary_markdown || null)
@@ -104,6 +111,27 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 		},
 		[mid, loadedFromCache, meetingTitle, meetingStartedAt, languageState.lastCustomLanguage, setLanguageState],
 	)
+
+	/**
+	 * Re-run timings, diarization and the summary for this meeting. Used for
+	 * recordings made before speaker labels existed. The backend clears `done`,
+	 * which puts this hook into its polling path.
+	 */
+	const handleRediarize = useCallback(async () => {
+		if (!mid) return
+		setIsProcessing(true)
+		try {
+			const res = await fetch(apiUrl(`/api/meetings/${mid}/rediarize`), { method: 'POST' })
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}))
+				throw new Error(body.detail || 'Could not start speaker identification.')
+			}
+			fetchMeetingData(false)
+		} catch (err) {
+			setIsProcessing(false)
+			setError(err instanceof Error ? err.message : 'Could not start speaker identification.')
+		}
+	}, [mid, fetchMeetingData])
 
 	const handleFeedbackToggle = async (type: string, isSelected: boolean) => {
 		if (!mid) return
@@ -245,6 +273,10 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 		currentMeetingLength,
 		submittedFeedback,
 		isRegenerating,
+		canRediarize,
+		speakerCount,
+		processingStage,
+		handleRediarize,
 		handleFeedbackToggle,
 		handleSuggestionSubmit,
 		handleRegenerate,

--- a/frontend/src/hooks/useRecording.ts
+++ b/frontend/src/hooks/useRecording.ts
@@ -75,6 +75,9 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 		isRecordingRef.current = isRecording
 	}, [isRecording])
 
+	// Which post-meeting stage the backend reports: 'diarizing' | 'summarizing'.
+	const [processingStage, setProcessingStage] = useState<string | null>(null)
+
 	const [isPaused, setIsPaused] = useState(false)
 	const isPausedRef = useRef(false)
 	useEffect(() => {
@@ -113,6 +116,7 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 		setTranscribedChunks(0)
 		setFirstChunkProcessedTime(null)
 		setTranscriptionStartTime(null)
+		setProcessingStage(null)
 		chunkIndexRef.current = 0
 		meetingId.current = null
 		setWakeLockStatus('inactive')
@@ -137,6 +141,7 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 			setExpectedTotalChunks(data.expected_chunks ?? null)
 			setLiveTranscript(data.transcript_text ?? '')
 			setTranscribedChunks(data.transcribed_chunks ?? 0)
+			setProcessingStage(data.processing_stage ?? null)
 
 			if (data.transcribed_chunks === 1 && !firstChunkProcessedTime) {
 				setFirstChunkProcessedTime(Date.now())
@@ -539,6 +544,7 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 		resumeRecording,
 		startFileProcessing,
 		transcriptionSpeedLabel,
+		processingStage,
 		analyserRef,
 		animationFrameRef,
 		updateContext,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,6 +13,59 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+/* ── Native UI colours ──────────────────────────────────────────────────────
+ * `color-scheme` is what makes the browser render scrollbars, text-selection
+ * handles, spinners and form controls dark. Without it they stay light in dark
+ * mode no matter what the app's own colours are. ThemeContext sets data-theme
+ * on <html>, and the media query covers the first paint before it does.
+ */
+:root {
+	color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme='light']) {
+		color-scheme: dark;
+	}
+}
+
+:root[data-theme='dark'] {
+	color-scheme: dark;
+}
+
+:root[data-theme='light'] {
+	color-scheme: light;
+}
+
+/* Explicit scrollbar colours so dark mode stays dark+grey rather than picking
+ * up a light track. Firefox uses scrollbar-color; WebKit needs the pseudos. */
+:root[data-theme='dark'] {
+	scrollbar-color: #3a4149 #181a1d;
+}
+
+:root[data-theme='dark'] ::-webkit-scrollbar {
+	width: 10px;
+	height: 10px;
+}
+
+:root[data-theme='dark'] ::-webkit-scrollbar-track {
+	background: #181a1d;
+}
+
+:root[data-theme='dark'] ::-webkit-scrollbar-thumb {
+	background: #3a4149;
+	border-radius: 5px;
+	border: 2px solid #181a1d;
+}
+
+:root[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+	background: #4a525c;
+}
+
+:root[data-theme='dark'] ::-webkit-scrollbar-corner {
+	background: #181a1d;
+}
+
 /* Additional global styles can go here */
 
 /* ── Summary title ───────────────────────────────────────────────────────── */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -212,6 +212,24 @@ body {
 	animation: pausedPulse 2s ease-in-out infinite;
 }
 
+@keyframes spinnerRotate {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.spinner {
+	animation: spinnerRotate 0.8s linear infinite;
+	transform-origin: 50% 50%;
+}
+
+/* Keep the motion cue without it being a fast rotation. */
+@media (prefers-reduced-motion: reduce) {
+	.spinner {
+		animation-duration: 2.5s;
+	}
+}
+
 @media (max-width: 640px) {
 	.page-container {
 		padding-left: 10px !important;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { ThemeContext } from '../contexts/ThemeContext'
 import { apiUrl } from '../utils/api'
 import { AppTheme, lightTheme, darkTheme } from '../styles/theme'
 import { DashboardStats, FeatureSuggestion } from '../types'
+import Spinner from '../components/Spinner'
 import StatCard from '../components/dashboard/StatCard'
 import BarChart from '../components/dashboard/BarChart'
 import PieChart from '../components/dashboard/PieChart'
@@ -83,7 +84,21 @@ export default function Dashboard() {
 		sky: { bg: theme === 'light' ? '#f0f9ff' : '#0c2f4a', border: theme === 'light' ? '#bae6fd' : '#0ea5e9', text: theme === 'light' ? '#0ea5e9' : '#bae6fd' },
 	}
 
-	if (isLoading) return <div style={{ color: currentThemeColors.text, textAlign: 'center', paddingTop: '50px' }}>Loading Dashboard...</div>
+	if (isLoading)
+		return (
+			<div
+				style={{
+					color: currentThemeColors.text,
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					gap: '10px',
+					paddingTop: '50px',
+				}}>
+				<Spinner label="Loading dashboard" />
+				Loading dashboard…
+			</div>
+		)
 	if (error) return <div style={{ color: 'red', textAlign: 'center', paddingTop: '50px' }}>Error: {error}</div>
 	if (!stats) return <div style={{ color: currentThemeColors.text, textAlign: 'center', paddingTop: '50px' }}>No stats available.</div>
 

--- a/frontend/src/pages/Record.tsx
+++ b/frontend/src/pages/Record.tsx
@@ -43,6 +43,7 @@ export default function Record() {
 		resumeRecording,
 		startFileProcessing,
 		transcriptionSpeedLabel,
+		processingStage,
 		analyserRef,
 		animationFrameRef,
 		updateContext,
@@ -165,6 +166,18 @@ export default function Record() {
 		}
 	}, [isPaused, isRecording, drawWaveform, animationFrameRef])
 
+	// Once recording stops the analyser is torn down, so the canvas would keep
+	// showing the last red frame frozen in place. Clear it instead.
+	useEffect(() => {
+		if (isRecording) return
+		if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current)
+		animationFrameRef.current = null
+
+		const canvas = canvasRef.current
+		const ctx = canvas?.getContext('2d')
+		if (canvas && ctx) ctx.clearRect(0, 0, canvas.width, canvas.height)
+	}, [isRecording, animationFrameRef])
+
 	const handleStart = () => {
 		if (audioSource === 'file') {
 			startFileProcessing(context)
@@ -286,6 +299,7 @@ export default function Record() {
 				expectedTotalChunks={expectedTotalChunks}
 				transcribedChunks={transcribedChunks}
 				transcriptionSpeedLabel={transcriptionSpeedLabel}
+				processingStage={processingStage}
 				liveTranscript={liveTranscript}
 				canvasRef={canvasRef}
 				audioSource={audioSource}

--- a/frontend/src/pages/Summary.tsx
+++ b/frontend/src/pages/Summary.tsx
@@ -8,7 +8,7 @@ import Spinner from '../components/Spinner'
 import { useTheme } from '../contexts/ThemeContext'
 import { lightTheme, darkTheme, AppTheme } from '../styles/theme'
 import FeedbackComponent from '../components/FeedbackComponent'
-import { CopyTextIcon, CopyMarkdownIcon, EditIcon, TrashIcon } from '../components/Icons'
+import { CopyTextIcon, CopyMarkdownIcon, EditIcon, TrashIcon, SpeakersIcon, CloseIcon } from '../components/Icons'
 import { removeMeeting } from '../utils/history'
 import FavoriteButton from '../components/FavoriteButton'
 import TagsManager from '../components/TagsManager'
@@ -49,6 +49,7 @@ export default function Summary() {
 	const navigate = useNavigate()
 	const { theme } = useTheme()
 	const currentThemeColors: AppTheme = theme === 'light' ? lightTheme : darkTheme
+	const isDark = theme !== 'light'
 	const { languageState, setLanguageState } = useSummaryLanguage()
 
 	const {
@@ -82,6 +83,9 @@ export default function Summary() {
 	const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'copied_md'>('idle')
 	const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 	const [transcriptCopied, setTranscriptCopied] = useState(false)
+	// Component state only: dismissing hides the hint for this visit and it
+	// reappears next time the meeting is opened, as requested.
+	const [speakerHintDismissed, setSpeakerHintDismissed] = useState(false)
 	const transcriptCopyTimerRef = useRef<NodeJS.Timeout | null>(null)
 	const [, setFavTagTick] = useState(0)
 	const refreshFavTags = useCallback(() => setFavTagTick((t) => t + 1), [])
@@ -447,6 +451,73 @@ export default function Summary() {
 				</div>
 			)}
 
+			{/* Offer diarization only where it can actually run: audio still on
+			    disk, and no speaker labels yet (i.e. recorded before the feature). */}
+			{canRediarize && !isDiarized && !speakerHintDismissed && !busy && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '12px',
+						margin: '0 0 12px',
+						padding: '10px 12px',
+						borderRadius: '10px',
+						backgroundColor: isDark ? 'rgba(245, 158, 11, 0.10)' : '#fffbeb',
+						border: `1px solid ${isDark ? 'rgba(245, 158, 11, 0.35)' : '#fde68a'}`,
+						color: currentThemeColors.text,
+						fontSize: '13px',
+						lineHeight: 1.45,
+					}}>
+					<span aria-hidden style={{ display: 'flex', color: '#f59e0b', flexShrink: 0 }}>
+						<SpeakersIcon size={18} />
+					</span>
+					<span style={{ flex: 1, minWidth: 0 }}>
+						<strong>New:</strong> MeetScribe can now tell speakers apart. Re-run this older
+						recording to label who said what — summaries then attribute decisions and action
+						items to the right person.
+					</span>
+					<button
+						onClick={handleRediarize}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: '5px',
+							padding: '5px 10px',
+							border: 'none',
+							borderRadius: '6px',
+							// Amber, matching the banner rather than the app's green primary.
+							backgroundColor: '#f59e0b',
+							color: '#ffffff',
+							fontSize: '13px',
+							fontWeight: '500',
+							fontFamily: 'inherit',
+							cursor: 'pointer',
+							whiteSpace: 'nowrap',
+							transition: 'all 0.2s ease',
+						}}>
+						<SpeakersIcon size={13} />
+						Find speakers
+					</button>
+					<button
+						onClick={() => setSpeakerHintDismissed(true)}
+						aria-label="Dismiss"
+						title="Dismiss"
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							padding: '4px',
+							border: 'none',
+							backgroundColor: 'transparent',
+							color: currentThemeColors.secondaryText,
+							lineHeight: 1,
+							cursor: 'pointer',
+							fontFamily: 'inherit',
+						}}>
+						<CloseIcon size={15} />
+					</button>
+				</div>
+			)}
+
 			{showRegeneratingBanner && (
 				<div
 					style={{
@@ -625,39 +696,6 @@ export default function Summary() {
 								</span>
 							) : null}
 						</span>
-						<span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-						{canRediarize && (
-							<button
-								onClick={(e) => {
-									e.stopPropagation()
-									handleRediarize()
-								}}
-								disabled={busy}
-								title={
-									isDiarized
-										? 'Re-run speaker identification and summary'
-										: 'Identify speakers in this recording and rewrite the summary'
-								}
-								style={{
-									padding: '5px 9px',
-									border: `1px solid ${currentThemeColors.border}`,
-									borderRadius: '6px',
-									backgroundColor: currentThemeColors.backgroundSecondary,
-									color: currentThemeColors.secondaryText,
-									cursor: busy ? 'not-allowed' : 'pointer',
-									opacity: busy ? 0.6 : 1,
-									display: 'flex',
-									alignItems: 'center',
-									gap: '5px',
-									fontSize: '13px',
-									lineHeight: 1,
-									fontFamily: 'inherit',
-									whiteSpace: 'nowrap',
-								}}>
-								{busy ? <Spinner size={13} /> : <span aria-hidden>🗣️</span>}
-								{isDiarized ? 'Redo speakers' : 'Find speakers'}
-							</button>
-						)}
 						<button
 							onClick={(e) => {
 								e.stopPropagation()
@@ -684,7 +722,6 @@ export default function Summary() {
 							}}>
 							{transcriptCopied ? <span>Copied!</span> : <CopyTextIcon size={13} />}
 						</button>
-						</span>
 					</h5>
 					{isTranscriptVisible && (
 						<pre style={{ marginTop: '8px', whiteSpace: 'pre-wrap', color: currentThemeColors.text, fontSize: '15px', lineHeight: '1.6' }}>{transcript}</pre>

--- a/frontend/src/pages/Summary.tsx
+++ b/frontend/src/pages/Summary.tsx
@@ -4,6 +4,7 @@ import { marked } from 'marked'
 import { apiUrl } from '../utils/api'
 import TurndownService from 'turndown'
 import ThemeToggle from '../components/ThemeToggle'
+import Spinner from '../components/Spinner'
 import { useTheme } from '../contexts/ThemeContext'
 import { lightTheme, darkTheme, AppTheme } from '../styles/theme'
 import FeedbackComponent from '../components/FeedbackComponent'
@@ -63,6 +64,10 @@ export default function Summary() {
 		currentMeetingLength,
 		submittedFeedback,
 		isRegenerating,
+		canRediarize,
+		speakerCount,
+		processingStage,
+		handleRediarize,
 		handleFeedbackToggle,
 		handleSuggestionSubmit,
 		handleRegenerate,
@@ -256,6 +261,20 @@ export default function Summary() {
 	const hasSummary = !!summaryMarkdown && !isProcessing
 	const displayLoading = isLoading && !loadedFromCache
 	const showProcessingMessage = (isProcessing || isRegenerating) && !summaryMarkdown
+	// Regenerating with a summary already on screen showed nothing at all, so
+	// changing the language looked like a no-op. Announce it and dim the stale text.
+	const showRegeneratingBanner = isRegenerating && !!summaryMarkdown
+	// A transcript recorded before diarization existed has no speaker labels.
+	const isDiarized = /^Speaker \d+:/m.test(transcript || '')
+	const busy = isProcessing || isRegenerating
+	const stageLabel =
+		processingStage === 'diarizing'
+			? 'Identifying speakers…'
+			: processingStage === 'transcribing'
+				? 'Re-transcribing audio…'
+				: processingStage === 'summarizing'
+					? 'Writing summary…'
+					: 'Processing summary, please wait…'
 
 	const copyButtonStyle: React.CSSProperties = {
 		padding: '7px 9px',
@@ -434,9 +453,31 @@ export default function Summary() {
 				</div>
 			)}
 
+			{showRegeneratingBanner && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '8px',
+						margin: '0 0 10px',
+						padding: '8px 12px',
+						borderRadius: '8px',
+						backgroundColor: currentThemeColors.backgroundSecondary,
+						border: `1px solid ${currentThemeColors.border}`,
+						color: currentThemeColors.secondaryText,
+						fontSize: '14px',
+					}}>
+					<Spinner label="Regenerating summary" />
+					Regenerating summary…
+				</div>
+			)}
+
 			{/* Summary */}
 			{displayLoading ? (
-				<p>Loading summary...</p>
+				<p style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+					<Spinner label="Loading summary" />
+					Loading summary…
+				</p>
 			) : error ? (
 				<p style={{ color: currentThemeColors.button.danger }}>Error: {error}</p>
 			) : hasSummary ? (
@@ -446,7 +487,8 @@ export default function Summary() {
 						borderRadius: '12px',
 						border: `1px solid ${currentThemeColors.border}`,
 						boxShadow: isEditing ? `0 0 0 2px ${currentThemeColors.input.border}` : 'none',
-						transition: 'box-shadow 0.15s ease',
+						opacity: showRegeneratingBanner ? 0.5 : 1,
+						transition: 'box-shadow 0.15s ease, opacity 0.2s ease',
 					}}>
 					{/* Editable area: title + body share onBlur so focus can move between them freely */}
 					<div onBlur={handleContainerBlur}>
@@ -543,7 +585,10 @@ export default function Summary() {
 					</div>
 				</div>
 			) : showProcessingMessage ? (
-				<p>⏳ Processing summary, please wait...</p>
+				<p style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+					<Spinner label={stageLabel} />
+					{stageLabel}
+				</p>
 			) : (
 				<p>No summary is available for this meeting.</p>
 			)}
@@ -580,7 +625,45 @@ export default function Summary() {
 								▶
 							</span>{' '}
 							🎤 Transcript
+							{speakerCount ? (
+								<span style={{ marginLeft: '8px', fontWeight: 400, fontSize: '13px', color: currentThemeColors.secondaryText }}>
+									{speakerCount} {speakerCount === 1 ? 'speaker' : 'speakers'}
+								</span>
+							) : null}
 						</span>
+						<span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+						{canRediarize && (
+							<button
+								onClick={(e) => {
+									e.stopPropagation()
+									handleRediarize()
+								}}
+								disabled={busy}
+								title={
+									isDiarized
+										? 'Re-run speaker identification and summary'
+										: 'Identify speakers in this recording and rewrite the summary'
+								}
+								style={{
+									padding: '5px 9px',
+									border: `1px solid ${currentThemeColors.border}`,
+									borderRadius: '6px',
+									backgroundColor: currentThemeColors.backgroundSecondary,
+									color: currentThemeColors.secondaryText,
+									cursor: busy ? 'not-allowed' : 'pointer',
+									opacity: busy ? 0.6 : 1,
+									display: 'flex',
+									alignItems: 'center',
+									gap: '5px',
+									fontSize: '13px',
+									lineHeight: 1,
+									fontFamily: 'inherit',
+									whiteSpace: 'nowrap',
+								}}>
+								{busy ? <Spinner size={13} /> : <span aria-hidden>🗣️</span>}
+								{isDiarized ? 'Redo speakers' : 'Find speakers'}
+							</button>
+						)}
 						<button
 							onClick={(e) => {
 								e.stopPropagation()
@@ -607,6 +690,7 @@ export default function Summary() {
 							}}>
 							{transcriptCopied ? <span>Copied!</span> : <CopyTextIcon size={13} />}
 						</button>
+						</span>
 					</h5>
 					{isTranscriptVisible && (
 						<pre style={{ marginTop: '8px', whiteSpace: 'pre-wrap', color: currentThemeColors.text, fontSize: '15px', lineHeight: '1.6' }}>{transcript}</pre>

--- a/frontend/src/pages/Summary.tsx
+++ b/frontend/src/pages/Summary.tsx
@@ -68,6 +68,7 @@ export default function Summary() {
 		speakerCount,
 		processingStage,
 		handleRediarize,
+		handleTranslate,
 		handleFeedbackToggle,
 		handleSuggestionSubmit,
 		handleRegenerate,
@@ -232,16 +233,7 @@ export default function Summary() {
 		const newState = { ...languageState, ...update }
 		setLanguageState(newState)
 		const targetLanguage = newState.mode === 'custom' ? newState.lastCustomLanguage : newState.mode
-		try {
-			const res = await fetch(apiUrl(`/api/meetings/${mid}/translate`), {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ target_language: targetLanguage, language_mode: newState.mode }),
-			})
-			if (!res.ok) throw new Error()
-		} catch {
-			alert('Could not start translation.')
-		}
+		await handleTranslate(targetLanguage, newState.mode)
 	}
 
 	const handleDelete = async () => {
@@ -258,15 +250,17 @@ export default function Summary() {
 
 	const formattedDate = formatMeetingDate(meetingStartedAt, meetingTimezone)
 	const contextHasChanged = editedContext !== null && context !== null && editedContext !== context
-	const hasSummary = !!summaryMarkdown && !isProcessing
+	const hasSummary = !!summaryMarkdown
 	const displayLoading = isLoading && !loadedFromCache
-	const showProcessingMessage = (isProcessing || isRegenerating) && !summaryMarkdown
-	// Regenerating with a summary already on screen showed nothing at all, so
-	// changing the language looked like a no-op. Announce it and dim the stale text.
-	const showRegeneratingBanner = isRegenerating && !!summaryMarkdown
+	// `isRegenerating` only covers the request itself; the work continues while
+	// `isProcessing` polls, so the indicator has to key off both.
+	const busy = isProcessing || isRegenerating
+	// Regenerating with a summary already on screen used to show nothing at all,
+	// so changing the language looked like a no-op. Announce it over the stale text.
+	const showRegeneratingBanner = busy && !!summaryMarkdown
+	const showProcessingMessage = busy && !summaryMarkdown
 	// A transcript recorded before diarization existed has no speaker labels.
 	const isDiarized = /^Speaker \d+:/m.test(transcript || '')
-	const busy = isProcessing || isRegenerating
 	const stageLabel =
 		processingStage === 'diarizing'
 			? 'Identifying speakers…'

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -213,6 +213,17 @@ function ensureNodeModules() {
 	run("pnpm", ["install"], { cwd: ROOT, shell: IS_WIN });
 }
 
+/**
+ * Fetch the speaker-diarization models if missing (~36 MB, once). The script
+ * is idempotent and never fatal: without models the app skips speaker labels.
+ */
+function ensureDiarizationModels() {
+	run(VENV_PYTHON, [join(BACKEND, "utils", "fetch_diarization_models.py")], {
+		cwd: BACKEND,
+		allowFailure: true,
+	});
+}
+
 function migrate() {
 	run(VENV_PYTHON, [join(BACKEND, "utils", "run_migrations.py")], { cwd: BACKEND });
 }
@@ -243,6 +254,7 @@ switch (command) {
 		ensureEnvFile();
 		ensureNodeModules();
 		ensurePythonEnv();
+		ensureDiarizationModels();
 		migrate();
 		checkFfmpeg();
 		log("Setup complete. Run `pnpm dev`.");
@@ -256,6 +268,7 @@ switch (command) {
 	case "backend":
 		ensureEnvFile();
 		ensurePythonEnv();
+		ensureDiarizationModels();
 		migrate();
 		checkFfmpeg();
 		backend();


### PR DESCRIPTION
## 🗣️ What

Speaker diarization running **locally on CPU**. After a meeting ends the recording is analysed and the transcript is labelled `Speaker 1`, `Speaker 2`, … before it goes to Claude, so summaries can attribute decisions to the right person.

Groq still produces the words — diarization only attaches labels to segments Whisper already returned, so the summarised text is byte-identical (verified: 334 words in, 334 out). ONNX/int8, no PyTorch, nothing leaves the machine.

## 📊 Tuned against AMI, not guesswork

Four 21-minute AMI meetings (4 speakers each, room-mic and headset) plus two of our own recordings:

| config | mean DER | speakers found (truth 4 each) | RTF |
|---|---|---|---|
| first attempt | 60.7% | 13, 15, 14, 14 | 0.19 |
| **shipped** | **22.6%** | **3, 4, 3, 4** | **0.02** |

Four things got it there: the right embedding model (biggest accuracy lever by far), threshold 0.9 as upstream recommends, pruning noise clusters by *share* of speech — an earlier "or ≥8 seconds" clause was under 1% of a long meeting, which is what invented 13 speakers — and `window_shift_ratio` 0.5, since the library default overlaps analysis windows by 90% and does ~10× redundant work.

That last one is **4.9× faster and slightly more accurate**, measured across all six recordings. Net cost is now ~1 minute per recorded hour on a dev box; 2 jobs × 2 threads by default, so a few concurrent meetings fit a 6-thread mini PC.

## ⚠️ Two things that mattered

**Chunks are not 30 seconds.** Chunk 0 measured 44.6s, and by chunk 11 the naive `index × 30` assumption was off by **+23s** — enough to silently pin every label to the wrong words. Positions come from real decoded sample counts. This also fixed `duration_seconds`.

**Diarization is best-effort.** Missing models or any exception falls back to the plain transcript, so a summary is never lost to it.

## 🖱️ UI

- Progress names the stage: "Identifying speakers…" / "Writing summary…".
- **Spinners**, which the app had none of, so every wait looked like a hang.
- A **"Find speakers"** button on the transcript, for meetings recorded before this existed. Only shows when the original audio survives.

## ⚡ Also fixed

- **Meeting loading**, 20.3ms → 3.1ms: `meetingchunk` had **no index at all** (23k rows, full-scanned several times per fetch), and the live transcript was rebuilt then discarded for finished meetings.
- Changing the summary language showed no feedback and didn't refresh — it used a different endpoint that set no state.
- `briefing` never interpolated the target language, so language choice was silently ignored there.
- Dark mode had light scrollbars (`color-scheme` was never declared).
- A transcription failure raised `AttributeError` and burned all three retries.

## ✅ Verified

Typecheck, lint, build clean. 14 unit checks on the merge logic. Shipped config re-measured end-to-end through the real code path. Both test meetings re-diarized.

## 📋 Known limits

- DER ~24% means roughly 1 speech-second in 4 lands on the wrong speaker — fine for "who raised what", not a verbatim record.
- Overlapping speech can't be represented; ~10% of AMI speech overlaps.
- Quiet participants (<6% of speech) get merged into a neighbour.
- No Docker build verified (daemon unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
