### PR TITLE
⚡ Experimental: transcribe + diarize on device (Parakeet), summarize with Claude

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -68,8 +68,18 @@ DIARIZATION_WINDOW_SHIFT_RATIO=0.5
 DIARIZATION_THREADS=2
 DIARIZATION_MAX_CONCURRENT=2
 
-# Where models live. Defaults to backend/data/models.
+# Where models live. Defaults to backend/data/models. The browser gets the
+# same two files from /api/models when it diarizes on-device.
 # DIARIZATION_MODEL_DIR=
+
+# ===== On-device transcription (experimental) =====
+# Where the browser fetches the ~0.7-1.3 GB Parakeet files from. Unset means
+# Hugging Face's own ysdede/parakeet-tdt-0.6b-v3-onnx. Point it at a repo of
+# your own (trailing slash required) to serve a custom build, e.g. the
+# weight-only int8 encoder from scripts/quantize_parakeet_encoder.py:
+#   VITE_PARAKEET_MODEL_BASE=https://huggingface.co/<user>/<repo>/resolve/main/
+# Read at build time, so `docker compose build frontend` after changing it.
+# VITE_PARAKEET_MODEL_BASE=
 
 # ===== Performance Tuning =====
 # Set the number of threads for OpenBLAS (used by Whisper's underlying libraries).

--- a/.env.sample
+++ b/.env.sample
@@ -73,18 +73,26 @@ DIARIZATION_MAX_CONCURRENT=2
 # DIARIZATION_MODEL_DIR=
 
 # ===== On-device transcription (experimental) =====
-# Where the browser fetches the ~0.7-1.3 GB Parakeet files from. Unset means
-# Hugging Face's own ysdede/parakeet-tdt-0.6b-v3-onnx. Point it at a repo of
-# your own (trailing slash required) to serve a custom build, e.g. the
-# weight-only int8 encoder from scripts/quantize_parakeet_encoder.py:
-#   VITE_PARAKEET_MODEL_BASE=https://huggingface.co/<user>/<repo>/resolve/main/
-# Read at build time, so `docker compose build frontend` after changing it.
-# VITE_PARAKEET_MODEL_BASE=
+# Where the browser fetches the Parakeet ONNX files from (trailing slash
+# required). Read at build time, so run `docker compose build frontend`
+# after changing it.
+#
+# Unset, the browser falls back to Hugging Face's own
+# ysdede/parakeet-tdt-0.6b-v3-onnx, whose fp32 encoder is ~2.4 GB and whose
+# fp16 branch needs WebGPU. The repo below is the weight-only int8 encoder
+# built by scripts/quantize_parakeet_encoder.py: 672 MB, runs on WASM, and
+# is what this project is tested against - keep it set unless you are
+# deliberately comparing builds.
+VITE_PARAKEET_MODEL_BASE=https://huggingface.co/hellguz/parakeet-tdt-0.6b-v3-onnx-q8/resolve/main/
 
 # ===== Performance Tuning =====
 # Set the number of threads for OpenBLAS (used by Whisper's underlying libraries).
 # Adjust based on your server's CPU cores. Default is 6.
 OPENBLAS_NUM_THREADS=6
+
+# ===== Summarization =====
+# Claude model used for summaries and generated titles.
+# SUMMARY_MODEL=claude-sonnet-5
 
 # ===== Background Worker =====
 # Number of threads for background tasks (transcription, summarization, translation).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ MeetScribe is a modern web application with a decoupled frontend and backend. Th
 
 ### Local Development (no Docker)
 
-**Prerequisites:** Node 18+, [pnpm](https://pnpm.io/installation), Python (the version
+**Prerequisites:** Node 20+, [pnpm](https://pnpm.io/installation), Python (the version
 in [.python-version](.python-version)), and `ffmpeg` on your PATH.
 
 > Local dev and the Docker image run the **same** Python version, so a bug that only

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     worker_threads: int = 4
 
     # Model used for summarization and title generation
-    summary_model: str = "claude-sonnet-4-6"
+    summary_model: str = "claude-sonnet-5"
 
     # Seconds of inactivity before a recording is auto-finalized
     inactivity_timeout_seconds: int = 120

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+import json
 import logging
 import shutil
 import uuid
@@ -15,6 +16,7 @@ from contextlib import asynccontextmanager
 from apscheduler.schedulers.background import BackgroundScheduler
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, SQLModel, create_engine, select, func
 from sqlalchemy import delete
@@ -37,8 +39,11 @@ from .models import (
     MeetingContextUpdate,
     MeetingTranslatePayload,
     SummaryUpdate,
+    ChunkTranscriptUpdate,
+    ClientFinalizePayload,
 )
 from . import tasks
+from . import diarization
 
 LOGGER = logging.getLogger("meetscribe")
 logging.basicConfig(
@@ -206,7 +211,10 @@ async def upload_chunk(
             )
         else:
             mc.path = str(chunk_path)
-            mc.text = None
+            # In on-device mode the browser may post a chunk's text before
+            # its audio finishes uploading; that text must survive.
+            if not mtg.client_processing:
+                mc.text = None
         db.add(mc)
 
         mtg.received_chunks += 1
@@ -228,13 +236,17 @@ async def upload_chunk(
 
         db.add(mtg)
         db.commit()
+        client_processing = mtg.client_processing
 
-    _executor.submit(
-        tasks.process_transcription_and_summary,
-        str(meeting_id),
-        chunk_index,
-        str(chunk_path.resolve()),
-    )
+    # On-device meetings are transcribed in the browser; the server only
+    # keeps the audio (for retention and a possible server-side re-run).
+    if not client_processing:
+        _executor.submit(
+            tasks.process_transcription_and_summary,
+            str(meeting_id),
+            chunk_index,
+            str(chunk_path.resolve()),
+        )
     return {"ok": True, "skipped": False}
 
 
@@ -296,6 +308,9 @@ def get_meeting(mid: uuid.UUID):
             and mtg.final_received
             and mtg.expected_chunks
             and transcribed_count >= mtg.expected_chunks
+            # On-device meetings finish through /finalize, once the browser
+            # has diarized. Until then every chunk having text means nothing.
+            and not (mtg.client_processing and not mtg.transcript_text)
         ):
             _executor.submit(tasks.generate_summary_only, str(mid))
             mtg.summary_task_queued = True
@@ -893,3 +908,143 @@ def translate_meeting(mid: uuid.UUID, payload: MeetingTranslatePayload):
     return {"ok": True, "message": "Translation task queued."}
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# On-device processing (experimental): the browser transcribes with Parakeet
+# and diarizes with the same ONNX models the server uses. Audio and chunk
+# texts are stored exactly as for a normal meeting; only summarization runs
+# here. See frontend/src/ondevice/.
+# ──────────────────────────────────────────────────────────────────────────────
+@app.put("/api/meetings/{mid}/chunks/{chunk_index}/transcript", status_code=200)
+def update_chunk_transcript(mid: uuid.UUID, chunk_index: int, payload: ChunkTranscriptUpdate):
+    """Store the text (and word timings) the browser produced for one chunk."""
+    with Session(engine) as db:
+        mtg = db.get(Meeting, mid)
+        if not mtg:
+            raise HTTPException(404, "Meeting not found")
+        if not mtg.client_processing:
+            raise HTTPException(409, "Meeting is not in on-device mode")
+
+        mc = db.exec(
+            select(MeetingChunk).where(
+                MeetingChunk.meeting_id == mid, MeetingChunk.chunk_index == chunk_index
+            )
+        ).first()
+        if not mc:
+            # Text can arrive before the audio upload; the path is filled in
+            # by /api/chunks when it lands.
+            mc = MeetingChunk(meeting_id=mid, chunk_index=chunk_index, path="")
+        mc.text = payload.text.strip()
+        mc.segments_json = (
+            json.dumps([s.model_dump() for s in payload.segments]) if payload.segments else None
+        )
+        mc.audio_seconds = payload.audio_seconds
+        mtg.last_activity = dt.datetime.utcnow()
+        db.add(mc)
+        db.add(mtg)
+        db.commit()
+    return {"ok": True}
+
+
+@app.post("/api/meetings/{mid}/finalize", status_code=202)
+def finalize_client_meeting(mid: uuid.UUID, payload: ClientFinalizePayload):
+    """The browser is done: take its labelled transcript and summarize it."""
+    with Session(engine) as db:
+        mtg = db.get(Meeting, mid)
+        if not mtg:
+            raise HTTPException(404, "Meeting not found")
+        if not mtg.client_processing:
+            raise HTTPException(409, "Meeting is not in on-device mode")
+        if mtg.done:
+            return {"ok": True, "already_done": True}
+
+        mtg.transcript_text = payload.transcript.strip()
+        mtg.speaker_count = payload.speaker_count
+        mtg.duration_seconds = payload.duration_seconds
+        mtg.client_stats = json.dumps(payload.client_stats) if payload.client_stats else None
+        mtg.diarization_attempted = payload.speaker_count is not None
+        mtg.final_received = True
+        if mtg.expected_chunks is None:
+            mtg.expected_chunks = mtg.received_chunks
+        mtg.last_activity = dt.datetime.utcnow()
+
+        queue = not mtg.summary_task_queued
+        mtg.summary_task_queued = True
+        db.add(mtg)
+        db.commit()
+
+    if queue:
+        _executor.submit(tasks.generate_summary_only, str(mid))
+    LOGGER.info("⚡ Meeting %s: on-device transcript received (%d chars). Summarizing.", mid, len(payload.transcript))
+    return {"ok": True}
+
+
+@app.post("/api/meetings/{mid}/client-fallback", status_code=202)
+def client_fallback(mid: uuid.UUID):
+    """
+    The browser gave up (model failed to load, tab ran out of memory, …).
+    Hand the meeting back to the normal server pipeline: transcribe every
+    chunk that has no text yet, then diarize and summarize as usual.
+    """
+    with Session(engine) as db:
+        mtg = db.get(Meeting, mid)
+        if not mtg:
+            raise HTTPException(404, "Meeting not found")
+        if not mtg.client_processing:
+            return {"ok": True, "requeued": 0}
+        mtg.client_processing = False
+        mtg.last_activity = dt.datetime.utcnow()
+        db.add(mtg)
+        db.commit()
+
+        pending = db.exec(
+            select(MeetingChunk.chunk_index, MeetingChunk.path)
+            .where(MeetingChunk.meeting_id == mid)
+            .where(MeetingChunk.text.is_(None))
+            .where(MeetingChunk.path != "")
+        ).all()
+
+    for chunk_index, path in pending:
+        _executor.submit(tasks.process_transcription_and_summary, str(mid), chunk_index, path)
+    LOGGER.warning("⚡ Meeting %s: browser fell back to server processing (%d chunk(s) re-queued).", mid, len(pending))
+    return {"ok": True, "requeued": len(pending)}
+
+
+@app.get("/api/models")
+def list_model_files():
+    """
+    What the browser needs to diarize on-device: the two ONNX models the
+    server already caches (served below — GitHub releases send no CORS
+    headers) and the tunables from .env, so both sides agree.
+    """
+    seg, emb = diarization.model_paths()
+    if not seg.exists() or not emb.exists():
+        raise HTTPException(
+            404, "Diarization models are not downloaded on the server (utils/fetch_diarization_models.py)."
+        )
+    return {
+        "segmentation": {"url": "/api/models/segmentation", "name": seg.name, "bytes": seg.stat().st_size},
+        "embedding": {"url": "/api/models/embedding", "name": emb.name, "bytes": emb.stat().st_size},
+        "config": {
+            "window_shift_ratio": settings.diarization_window_shift_ratio,
+            "cluster_threshold": settings.diarization_cluster_threshold,
+            "min_speaker_share": settings.diarization_min_speaker_share,
+            "min_duration_on": settings.diarization_min_duration_on,
+            "min_duration_off": settings.diarization_min_duration_off,
+        },
+    }
+
+
+@app.get("/api/models/{name}")
+def get_model_file(name: str):
+    seg, emb = diarization.model_paths()
+    path = {"segmentation": seg, "embedding": emb}.get(name)
+    if path is None:
+        raise HTTPException(404, "Unknown model")
+    if not path.exists():
+        raise HTTPException(404, "Model not downloaded on the server")
+    return FileResponse(
+        path,
+        media_type="application/octet-stream",
+        filename=path.name,
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -48,6 +48,14 @@ class Meeting(SQLModel, table=True):
     # predating the feature are False, which is what the "find speakers"
     # hint keys off. Absence of Speaker labels is NOT the same thing.
     diarization_attempted: bool = False
+    # Experimental: transcription and diarization ran in the user's browser
+    # (Parakeet + pyannote/campplus via ONNX Runtime Web). The server still
+    # stores the audio and chunk texts as usual, but must neither transcribe
+    # nor diarize — it only summarizes the transcript the client hands over.
+    client_processing: bool = False
+    # JSON blob of what the browser measured: model download size/time,
+    # transcription speed, diarization time, backend used. Purely informative.
+    client_stats: str | None = None
 
 
 class MeetingChunk(SQLModel, table=True):
@@ -96,6 +104,7 @@ class MeetingCreate(SQLModel):
     summary_custom_language: str | None = None
     context: str | None = None
     timezone: str | None = None
+    client_processing: bool = False
 
 
 class FeedbackCreate(SQLModel):
@@ -150,7 +159,35 @@ class MeetingStatus(SQLModel):
     diarization_attempted: bool = False
     # True when the original audio survives, so speakers can still be identified.
     can_rediarize: bool = False
+    client_processing: bool = False
+    client_stats: str | None = None
     feedback: list[str] = []  # List of submitted feedback types
+
+
+class ChunkSegment(SQLModel):
+    start: float
+    end: float
+    text: str
+
+
+class ChunkTranscriptUpdate(SQLModel):
+    """One chunk transcribed in the browser (on-device mode)."""
+
+    text: str
+    segments: list[ChunkSegment] = []
+    audio_seconds: float | None = None
+
+
+class ClientFinalizePayload(SQLModel):
+    """
+    The browser finished transcribing and diarizing: here is the labelled
+    transcript, summarize it. `client_stats` is free-form JSON for the UI.
+    """
+
+    transcript: str
+    speaker_count: int | None = None
+    duration_seconds: int | None = None
+    client_stats: dict | None = None
 
 
 class MeetingTitleUpdate(SQLModel):

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -383,7 +383,18 @@ def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
     final_transcript = plain_transcript
     duration_seconds = num_chunks * 30
 
-    if plain_transcript and diarization.is_enabled():
+    if mtg.client_processing:
+        # The browser transcribed and diarized. It handed us the labelled
+        # transcript and the real duration via /finalize; if it never did
+        # (tab closed mid-way), the plain chunk texts are the best we have.
+        if mtg.transcript_text and mtg.transcript_text.strip():
+            final_transcript = mtg.transcript_text
+        if mtg.duration_seconds:
+            duration_seconds = mtg.duration_seconds
+        if mtg.processing_total is None:
+            mtg.processing_total = 1
+
+    if plain_transcript and diarization.is_enabled() and not mtg.client_processing:
         # A fresh recording was transcribed live, so this run is diarize +
         # summarize. Reprocessing sets 3 before calling us.
         if mtg.processing_total is None:
@@ -414,7 +425,8 @@ def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
     mtg.transcript_text = final_transcript
 
     if final_transcript:
-        mtg.word_count = word_count
+        # An on-device transcript may hold text the chunk rows never got.
+        mtg.word_count = word_count or len(final_transcript.split())
         mtg.duration_seconds = duration_seconds
 
         mtg.processing_stage = "summarizing"
@@ -454,7 +466,7 @@ def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
     # Mark it seen even when diarization produced nothing (silent recording,
     # empty transcript): the pipeline had its chance, so the "find speakers"
     # hint must not keep offering a re-run that would change nothing.
-    if diarization.is_enabled():
+    if diarization.is_enabled() and not mtg.client_processing:
         mtg.diarization_attempted = True
     mtg.done = True
     db.add(mtg)
@@ -697,6 +709,9 @@ def rediarize_meeting_in_worker(meeting_id_str: str, retranscribe: bool = True) 
             LOGGER.info("♻️  Meeting %s: re-running diarization and summary.", meeting_id_str)
             mtg.done = False
             mtg.summary_task_queued = False
+            # From here on the server owns the transcript, even if the browser
+            # produced the original one; finalize would otherwise keep it.
+            mtg.client_processing = False
             finalize_meeting_processing(db, mtg)
             LOGGER.info("✅ Meeting %s re-diarized.", meeting_id_str)
 

--- a/backend/utils/add_client_processing_columns.py
+++ b/backend/utils/add_client_processing_columns.py
@@ -1,0 +1,60 @@
+"""
+utils/add_client_processing_columns.py
+────────────────────────────────────────────────────────
+Adds the columns the on-device (browser) processing mode needs:
+
+  meeting.client_processing — transcription + diarization happen in the
+                              browser; the server only stores audio and
+                              summarizes the transcript it is handed
+  meeting.client_stats      — JSON with the timings the browser measured
+                              (model download, transcription speed, …)
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+# --- Locate backend package ---
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from migration_helper import ensure_database_exists
+from sqlalchemy import text
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+log = logging.getLogger("migration")
+
+COLUMNS = [
+    ("meeting", "client_processing", "BOOLEAN DEFAULT 0"),
+    ("meeting", "client_stats", "TEXT"),
+]
+
+
+def run_migration():
+    db_path, engine = ensure_database_exists()
+
+    with engine.connect() as connection:
+        with connection.begin():
+            try:
+                for table, column, coltype in COLUMNS:
+                    result = connection.execute(text(f"PRAGMA table_info({table});"))
+                    existing = [row[1] for row in result]
+                    if not existing:
+                        log.info("Table `%s` does not exist yet; skipping.", table)
+                        continue
+                    if column in existing:
+                        log.info("`%s.%s` already exists.", table, column)
+                        continue
+                    log.info("Adding `%s` column to `%s` table...", column, table)
+                    connection.execute(
+                        text(f"ALTER TABLE {table} ADD COLUMN {column} {coltype};")
+                    )
+
+                log.info("Migration successful.")
+            except Exception as e:
+                log.error("An error occurred during migration: %s", e, exc_info=True)
+
+
+if __name__ == "__main__":
+    run_migration()

--- a/backend/utils/run_migrations.py
+++ b/backend/utils/run_migrations.py
@@ -31,6 +31,7 @@ MIGRATIONS = [
     "add_enhanced_section_columns.py",
     "add_diarization_columns.py",
     "add_meeting_id_indexes.py",
+    "add_client_processing_columns.py",
 ]
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+        VITE_PARAKEET_MODEL_BASE: ${VITE_PARAKEET_MODEL_BASE:-}
     ports:
       - "4132:80"
     env_file: [.env]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,10 @@
 FROM node:18-alpine AS build
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+# Where the browser fetches the Parakeet files for on-device transcription.
+# Empty means Hugging Face's own copy; see .env.sample.
+ARG VITE_PARAKEET_MODEL_BASE
+ENV VITE_PARAKEET_MODEL_BASE=${VITE_PARAKEET_MODEL_BASE}
 
 WORKDIR /web
 COPY package.json package-lock.json ./

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 # ─── build ────────────────────────────────────────────────────────────────────
-FROM node:18-alpine AS build
+# 20+ for import.meta.resolve, which vite.config.ts uses to pin ONNX Runtime.
+FROM node:22-alpine AS build
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 # Where the browser fetches the Parakeet files for on-device transcription.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,8 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
 			href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Jost:ital,wght@0,100..900;1,100..900&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"
-			rel="stylesheet" />
+			rel="stylesheet"
+			crossorigin="anonymous" />
 	</head>
 
 	<body>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -16,6 +16,12 @@ server {
   location / {
     root /usr/share/nginx/html;
     try_files $uri /index.html;
+    # Cross-origin isolation: enables SharedArrayBuffer, so the on-device
+    # transcription/diarization can run WASM multi-threaded. Every cross-origin
+    # resource the page loads must then send CORS/CORP headers (Google Fonts
+    # and the Hugging Face model files do).
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Embedder-Policy "require-corp" always;
   }
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@fontsource/inter": "^5.0.18",
         "marked": "^17.0.5",
+        "onnxruntime-web": "1.24.1",
+        "parakeet.js": "1.4.4",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-router-dom": "^6.23.0",
@@ -982,6 +984,63 @@
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1341,7 +1400,6 @@
       "version": "22.15.29",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
       "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2247,6 +2305,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -2301,6 +2365,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2492,6 +2562,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2579,6 +2655,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.1.tgz",
+      "integrity": "sha512-UnV15u4p4XxoIV+jFP4hXPsW93s3QrwLSpi20HUDYHoTfI4z4sjzex3L4XDOxGGZJ/M/catrwAG2go958UQq0w==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.24.1.tgz",
+      "integrity": "sha512-i2u395dv+ZEQBdH+aORvlu19Bzvlg5AXJ7wjxnL350hknOP9z0UeP3pVfjkpMEWMPy2T6nCQxetKTmNia6wSzg==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.1",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2627,6 +2723,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parakeet.js": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/parakeet.js/-/parakeet.js-1.4.4.tgz",
+      "integrity": "sha512-+tYIDgp799bvsDye3y2lFyspYHgTOJ5YMZi0mWYABXyJjp/3NZmNaMTnS9jhf4qlIQJoBk0Nmj+UwsI3zk+Aqg==",
+      "license": "MIT",
+      "dependencies": {
+        "onnxruntime-web": "1.24.1"
       }
     },
     "node_modules/parent-module": {
@@ -2682,6 +2787,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.4",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
@@ -2735,6 +2846,29 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -3036,7 +3170,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fontsource/inter": "^5.0.18",
         "marked": "^17.0.5",
-        "onnxruntime-web": "1.24.1",
+        "onnxruntime-web": "1.29.0",
         "parakeet.js": "1.4.4",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -2656,21 +2656,21 @@
       "license": "MIT"
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.1.tgz",
-      "integrity": "sha512-UnV15u4p4XxoIV+jFP4hXPsW93s3QrwLSpi20HUDYHoTfI4z4sjzex3L4XDOxGGZJ/M/catrwAG2go958UQq0w==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.29.0.tgz",
+      "integrity": "sha512-/F63/e2VJoaVXGGNu6S5QH7jivBThGO95OzAVXXQ8hTta/b1QxI8udHa6cI3+3mAb5WWIIaMMwfZw01oivjJ1g==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.24.1.tgz",
-      "integrity": "sha512-i2u395dv+ZEQBdH+aORvlu19Bzvlg5AXJ7wjxnL350hknOP9z0UeP3pVfjkpMEWMPy2T6nCQxetKTmNia6wSzg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.29.0.tgz",
+      "integrity": "sha512-LuQlpX6MFLJZu756erwUeb1mNfoJGbs1kzDwJGNlf5RvfYMdqhcY3vNpDPK40CUV2HoWTkIj+uS0o36GFHjeYw==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
         "long": "^5.2.3",
-        "onnxruntime-common": "1.24.1",
+        "onnxruntime-common": "1.29.0",
         "platform": "^1.3.6",
         "protobufjs": "^7.2.4"
       }
@@ -2732,6 +2732,26 @@
       "license": "MIT",
       "dependencies": {
         "onnxruntime-web": "1.24.1"
+      }
+    },
+    "node_modules/parakeet.js/node_modules/onnxruntime-common": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.1.tgz",
+      "integrity": "sha512-UnV15u4p4XxoIV+jFP4hXPsW93s3QrwLSpi20HUDYHoTfI4z4sjzex3L4XDOxGGZJ/M/catrwAG2go958UQq0w==",
+      "license": "MIT"
+    },
+    "node_modules/parakeet.js/node_modules/onnxruntime-web": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.24.1.tgz",
+      "integrity": "sha512-i2u395dv+ZEQBdH+aORvlu19Bzvlg5AXJ7wjxnL350hknOP9z0UeP3pVfjkpMEWMPy2T6nCQxetKTmNia6wSzg==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.1",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
       }
     },
     "node_modules/parent-module": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@fontsource/inter": "^5.0.18",
     "marked": "^17.0.5",
-    "onnxruntime-web": "1.24.1",
+    "onnxruntime-web": "1.29.0",
     "parakeet.js": "1.4.4",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@fontsource/inter": "^5.0.18",
     "marked": "^17.0.5",
+    "onnxruntime-web": "1.24.1",
+    "parakeet.js": "1.4.4",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^6.23.0",

--- a/frontend/src/components/InfoPanel.tsx
+++ b/frontend/src/components/InfoPanel.tsx
@@ -10,6 +10,13 @@ const REPO_URL = 'https://github.com/hellguz/meetscribe'
  */
 const CHANGELOG: { when: string; lines: string[] }[] = [
 	{
+		when: 'September 2026',
+		lines: [
+			'⚡ Experimental: transcribe and label speakers right in your browser — only the finished text reaches the server, and Claude still writes the summary.',
+			'One model download of about 0.7 GB, cached for next time. Live recordings, 25 European languages.',
+		],
+	},
+	{
 		when: 'August 2026',
 		lines: [
 			'🗣️ Speaker labels — MeetScribe now works out who said what, on your own machine.',

--- a/frontend/src/components/OnDevicePanel.tsx
+++ b/frontend/src/components/OnDevicePanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { AppTheme } from '../styles/theme'
 import type { OnDeviceController } from '../ondevice/useOnDevice'
 import { PLAN_DOWNLOAD_BYTES, PLAN_LABELS, type PlanChoice } from '../ondevice/capabilities'
@@ -27,7 +27,15 @@ const STAGE_LABEL: Record<string, string> = {
  */
 const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked }) => {
 	const { state, setEnabled, setPlanChoice } = controller
-	const { enabled, phase, caps, plan, download, transcription, diarization, error } = state
+	const { enabled, phase, caps, plan, download, transcription, diarization, error, statusText, log, autoFallbackPlan, autoFallbackReason } = state
+	const [showLog, setShowLog] = useState(false)
+	// Re-render once a second while loading, so "… 42s" ticks.
+	const [, setTick] = useState(0)
+	useEffect(() => {
+		if (phase !== 'loading') return
+		const id = setInterval(() => setTick((t) => t + 1), 1000)
+		return () => clearInterval(id)
+	}, [phase])
 
 	const chip = (active: boolean): React.CSSProperties => ({
 		padding: '4px 10px',
@@ -51,15 +59,19 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 		if (phase === 'error') return { icon: '❌', text: error ?? 'Failed' }
 		if (phase === 'fallback') return { icon: '↩️', text: `Handed over to the server${error ? ` (${error})` : ''}` }
 		if (phase === 'loading') {
-			if (download && !download.done && download.total > 0) return { icon: '⬇️', text: `Downloading Parakeet ${formatBytes(download.loaded)} / ${formatBytes(download.total)} · ${formatBytes(download.bytesPerSec)}/s${downloadEta !== null ? ` · ~${formatSeconds(downloadEta)} left` : ''}` }
-			return { icon: '⏳', text: download?.done ? 'Loading model into memory…' : caps ? 'Preparing model (cached files load instantly)…' : 'Checking this device…' }
+			const downloading = download && !download.done && download.total > 0 && download.loaded < download.total
+			if (downloading) return { icon: '⬇️', text: `Downloading Parakeet ${formatBytes(download.loaded)} / ${formatBytes(download.total)} · ${formatBytes(download.bytesPerSec)}/s${downloadEta !== null ? ` · ~${formatSeconds(downloadEta)} left` : ''}` }
+			const since = download?.doneAt ?? download?.startedAt ?? null
+			const elapsed = since ? ` · ${formatSeconds((Date.now() - since) / 1000)}` : ''
+			const slow = since && Date.now() - since > 120_000 ? ' — taking long; if it never finishes the model may not fit in memory (try the CPU plan, or turn the switch off to record via the server)' : ''
+			return { icon: '⏳', text: `${statusText ?? (download?.cached ? 'Loading cached model…' : 'Preparing model…')}${elapsed}${slow}` }
 		}
 		if (phase === 'ready' || phase === 'diarizing' || phase === 'finalizing') {
 			const parts: string[] = []
 			if (state.backend) parts.push(state.backend === 'webgpu' ? 'GPU (WebGPU)' : `CPU · ${state.threads ?? 1} thread${(state.threads ?? 1) === 1 ? '' : 's'}`)
 			if (state.modelLoadMs !== null) parts.push(`ready in ${formatSeconds(state.modelLoadMs / 1000)}`)
-			if (download?.done && download.total > 0) parts.push(`downloaded ${formatBytes(download.total)} in ${formatSeconds((download.loaded / Math.max(download.bytesPerSec, 1)))}`)
-			else if (download?.done) parts.push('models were cached')
+			if (download?.done && download.total > 0 && !download.cached) parts.push(`downloaded ${formatBytes(download.total)} in ${formatSeconds(download.loaded / Math.max(download.bytesPerSec, 1))}`)
+			else if (download?.done) parts.push(`${formatBytes(download.total)} from cache`)
 			return { icon: '✅', text: parts.join(' · ') }
 		}
 		return null
@@ -113,7 +125,24 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 				</div>
 			)}
 
-			{enabled && phase === 'loading' && download && !download.done && download.total > 0 && (
+			{enabled && autoFallbackPlan && (
+				<div style={{ margin: `6px 0 0 ${locked ? 0 : 26}px`, color: '#d97706', wordBreak: 'break-word' }}>
+					⚠️ GPU plan failed ({autoFallbackReason}); switched to CPU · int8.
+				</div>
+			)}
+
+			{enabled && log.length > 0 && (phase === 'loading' || phase === 'error' || phase === 'fallback') && (
+				<div style={{ margin: `6px 0 0 ${locked ? 0 : 26}px`, fontSize: '11px', color: theme.secondaryText, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}>
+					<div style={{ cursor: 'pointer', userSelect: 'none', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }} onClick={() => setShowLog((v) => !v)} title="Worker log">
+						{showLog ? '▾' : '▸'} {log[log.length - 1]}
+					</div>
+					{showLog && (
+						<pre style={{ margin: '4px 0 0', maxHeight: 160, overflow: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word', padding: '6px 8px', borderRadius: 6, backgroundColor: theme.backgroundSecondary }}>{log.join('\n')}</pre>
+					)}
+				</div>
+			)}
+
+			{enabled && phase === 'loading' && download && !download.done && download.total > 0 && download.loaded < download.total && (
 				<div style={{ height: 6, borderRadius: 3, backgroundColor: theme.backgroundSecondary, overflow: 'hidden', margin: `6px 0 0 ${locked ? 0 : 26}px` }}>
 					<div style={{ width: `${downloadPct}%`, height: '100%', backgroundColor: theme.text, transition: 'width 0.3s' }} />
 				</div>

--- a/frontend/src/components/OnDevicePanel.tsx
+++ b/frontend/src/components/OnDevicePanel.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { AppTheme } from '../styles/theme'
 import type { OnDeviceController } from '../ondevice/useOnDevice'
-import { PLAN_DOWNLOAD_BYTES, PLAN_LABELS, type PlanChoice } from '../ondevice/capabilities'
+import { PLAN_LABELS, type ParakeetPlan, type PlanChoice } from '../ondevice/capabilities'
+import { measurePlanBytes } from '../ondevice/hub'
 
 interface OnDevicePanelProps {
 	controller: OnDeviceController
@@ -37,6 +38,23 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 		return () => clearInterval(id)
 	}, [phase])
 
+	// What each plan actually downloads from the configured host, which is a
+	// build-time setting and so not knowable from a constant here.
+	const [planSizes, setPlanSizes] = useState<Partial<Record<ParakeetPlan, number>>>({})
+	useEffect(() => {
+		if (!enabled || locked) return
+		let live = true
+		const base = (import.meta.env.VITE_PARAKEET_MODEL_BASE as string | undefined) || undefined
+		for (const p of ['gpu-fp16', 'cpu-int8'] as ParakeetPlan[]) {
+			measurePlanBytes(p, base).then((bytes) => {
+				if (live && bytes) setPlanSizes((sizes) => ({ ...sizes, [p]: bytes }))
+			})
+		}
+		return () => {
+			live = false
+		}
+	}, [enabled, locked])
+
 	const chip = (active: boolean): React.CSSProperties => ({
 		padding: '4px 10px',
 		borderRadius: '999px',
@@ -51,7 +69,7 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 	const speed = transcription.processMs > 0 ? transcription.audioSeconds / (transcription.processMs / 1000) : null
 	const downloadPct = download && download.total > 0 ? Math.min(100, (download.loaded / download.total) * 100) : 0
 	const downloadEta = download && download.bytesPerSec > 0 && !download.done ? (download.total - download.loaded) / download.bytesPerSec : null
-	const planBytes = plan ? PLAN_DOWNLOAD_BYTES[plan] : null
+	const planBytes = plan ? planSizes[plan] ?? null : null
 
 	const statusLine = (() => {
 		if (!enabled) return null
@@ -106,7 +124,7 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 				<div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', margin: '8px 0 0 26px', alignItems: 'center' }}>
 					{(['auto', 'gpu-fp16', 'cpu-int8'] as PlanChoice[]).map((choice) => (
 						<span key={choice} style={chip(state.planChoice === choice)} onClick={() => !locked && setPlanChoice(choice)}>
-							{choice === 'auto' ? `Auto${caps ? ` → ${PLAN_LABELS[caps.recommended].split(' · ')[0]}` : ''}` : PLAN_LABELS[choice]}
+							{choice === 'auto' ? `Auto${caps ? ` → ${PLAN_LABELS[caps.recommended]}` : ''}` : `${PLAN_LABELS[choice]}${planSizes[choice] ? ` · ${formatBytes(planSizes[choice]!)}` : ''}`}
 						</span>
 					))}
 					{planBytes && phase === 'idle' && <span style={{ color: theme.secondaryText }}>~{formatBytes(planBytes)} once, then cached</span>}
@@ -129,7 +147,7 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 
 			{enabled && autoFallbackPlan && (
 				<div style={{ margin: `6px 0 0 ${locked ? 0 : 26}px`, color: '#d97706', wordBreak: 'break-word' }}>
-					⚠️ GPU plan failed ({autoFallbackReason}); switched to CPU · int8.
+					⚠️ GPU plan failed ({autoFallbackReason}); switched to the CPU plan.
 				</div>
 			)}
 

--- a/frontend/src/components/OnDevicePanel.tsx
+++ b/frontend/src/components/OnDevicePanel.tsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import { AppTheme } from '../styles/theme'
+import type { OnDeviceController } from '../ondevice/useOnDevice'
+import { PLAN_DOWNLOAD_BYTES, PLAN_LABELS, type PlanChoice } from '../ondevice/capabilities'
+
+interface OnDevicePanelProps {
+	controller: OnDeviceController
+	theme: AppTheme
+	/** Recording or processing: hide the controls, keep the live numbers. */
+	locked: boolean
+}
+
+export const formatBytes = (bytes: number) => (bytes >= 1e9 ? `${(bytes / 1e9).toFixed(2)} GB` : bytes >= 1e6 ? `${Math.round(bytes / 1e6)} MB` : `${Math.round(bytes / 1e3)} kB`)
+const formatSeconds = (s: number) => (s >= 60 ? `${Math.floor(s / 60)}m ${Math.round(s % 60)}s` : `${s.toFixed(s < 10 ? 1 : 0)}s`)
+
+const STAGE_LABEL: Record<string, string> = {
+	segmenting: 'Finding speech',
+	embedding: 'Fingerprinting voices',
+	clustering: 'Grouping speakers',
+}
+
+/**
+ * The "⚡ On this device" card on the record page: a switch, the model plan,
+ * device warnings, and — once enabled — live numbers for the download, the
+ * transcription speed and the speaker pass. Everything it shows is measured
+ * in the browser; nothing comes from the server.
+ */
+const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked }) => {
+	const { state, setEnabled, setPlanChoice } = controller
+	const { enabled, phase, caps, plan, download, transcription, diarization, error } = state
+
+	const chip = (active: boolean): React.CSSProperties => ({
+		padding: '4px 10px',
+		borderRadius: '999px',
+		fontSize: '12px',
+		border: `1px solid ${active ? theme.text : theme.border}`,
+		backgroundColor: active ? theme.text : 'transparent',
+		color: active ? theme.body : theme.secondaryText,
+		cursor: locked ? 'default' : 'pointer',
+		userSelect: 'none',
+	})
+
+	const speed = transcription.processMs > 0 ? transcription.audioSeconds / (transcription.processMs / 1000) : null
+	const downloadPct = download && download.total > 0 ? Math.min(100, (download.loaded / download.total) * 100) : 0
+	const downloadEta = download && download.bytesPerSec > 0 && !download.done ? (download.total - download.loaded) / download.bytesPerSec : null
+	const planBytes = plan ? PLAN_DOWNLOAD_BYTES[plan] : null
+
+	const statusLine = (() => {
+		if (!enabled) return null
+		if (phase === 'idle') return { icon: '⏳', text: 'Checking this device…' }
+		if (phase === 'error') return { icon: '❌', text: error ?? 'Failed' }
+		if (phase === 'fallback') return { icon: '↩️', text: `Handed over to the server${error ? ` (${error})` : ''}` }
+		if (phase === 'loading') {
+			if (download && !download.done && download.total > 0) return { icon: '⬇️', text: `Downloading Parakeet ${formatBytes(download.loaded)} / ${formatBytes(download.total)} · ${formatBytes(download.bytesPerSec)}/s${downloadEta !== null ? ` · ~${formatSeconds(downloadEta)} left` : ''}` }
+			return { icon: '⏳', text: download?.done ? 'Loading model into memory…' : caps ? 'Preparing model (cached files load instantly)…' : 'Checking this device…' }
+		}
+		if (phase === 'ready' || phase === 'diarizing' || phase === 'finalizing') {
+			const parts: string[] = []
+			if (state.backend) parts.push(state.backend === 'webgpu' ? 'GPU (WebGPU)' : `CPU · ${state.threads ?? 1} thread${(state.threads ?? 1) === 1 ? '' : 's'}`)
+			if (state.modelLoadMs !== null) parts.push(`ready in ${formatSeconds(state.modelLoadMs / 1000)}`)
+			if (download?.done && download.total > 0) parts.push(`downloaded ${formatBytes(download.total)} in ${formatSeconds((download.loaded / Math.max(download.bytesPerSec, 1)))}`)
+			else if (download?.done) parts.push('models were cached')
+			return { icon: '✅', text: parts.join(' · ') }
+		}
+		return null
+	})()
+
+	return (
+		<div
+			style={{
+				marginBottom: '12px',
+				padding: '10px 14px',
+				borderRadius: '12px',
+				border: `1px solid ${enabled ? theme.text : theme.border}`,
+				backgroundColor: theme.background,
+				fontSize: '13px',
+				color: theme.text,
+			}}>
+			<label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: locked ? 'default' : 'pointer' }}>
+				<input type="checkbox" checked={enabled} disabled={locked} onChange={(e) => setEnabled(e.target.checked)} style={{ width: 16, height: 16, margin: 0, accentColor: theme.text }} />
+				<span style={{ fontWeight: 600 }}>⚡ Transcribe on this device</span>
+				<span style={{ fontSize: '11px', color: theme.secondaryText, letterSpacing: '0.08em', border: `1px solid ${theme.border}`, borderRadius: 4, padding: '1px 5px' }}>EXPERIMENTAL</span>
+			</label>
+
+			{!locked && (
+				<p style={{ margin: '6px 0 0 26px', color: theme.secondaryText, lineHeight: 1.45 }}>
+					Parakeet TDT 0.6B v3 (25 European languages) and speaker identification run in your browser; only the text goes to the server, which still stores the audio and writes the Claude summary. Live recordings only.
+				</p>
+			)}
+
+			{enabled && !locked && (
+				<div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', margin: '8px 0 0 26px', alignItems: 'center' }}>
+					{(['auto', 'gpu-fp16', 'cpu-int8'] as PlanChoice[]).map((choice) => (
+						<span key={choice} style={chip(state.planChoice === choice)} onClick={() => !locked && setPlanChoice(choice)}>
+							{choice === 'auto' ? `Auto${caps ? ` → ${PLAN_LABELS[caps.recommended].split(' · ')[0]}` : ''}` : PLAN_LABELS[choice]}
+						</span>
+					))}
+					{planBytes && phase === 'idle' && <span style={{ color: theme.secondaryText }}>~{formatBytes(planBytes)} once, then cached</span>}
+				</div>
+			)}
+
+			{enabled && !locked && caps && caps.warnings.length > 0 && (
+				<ul style={{ margin: '8px 0 0 26px', padding: 0, listStyle: 'none', color: '#d97706', lineHeight: 1.4 }}>
+					{caps.warnings.map((w) => (
+						<li key={w}>⚠️ {w}</li>
+					))}
+				</ul>
+			)}
+
+			{statusLine && (
+				<div style={{ margin: `8px 0 0 ${locked ? 0 : 26}px`, color: phase === 'error' ? theme.button.danger : theme.secondaryText, wordBreak: 'break-word' }}>
+					{statusLine.icon} {statusLine.text}
+				</div>
+			)}
+
+			{enabled && phase === 'loading' && download && !download.done && download.total > 0 && (
+				<div style={{ height: 6, borderRadius: 3, backgroundColor: theme.backgroundSecondary, overflow: 'hidden', margin: `6px 0 0 ${locked ? 0 : 26}px` }}>
+					<div style={{ width: `${downloadPct}%`, height: '100%', backgroundColor: theme.text, transition: 'width 0.3s' }} />
+				</div>
+			)}
+
+			{enabled && locked && (transcription.done > 0 || transcription.queued > 0) && (
+				<div style={{ marginTop: 6, color: theme.secondaryText }}>
+					🎤 Transcribed {transcription.done} chunk{transcription.done === 1 ? '' : 's'}
+					{transcription.queued > 0 ? ` · ${transcription.queued} waiting` : ''}
+					{speed !== null ? ` · ${speed.toFixed(1)}× realtime` : ''}
+					{transcription.done > 0 ? ` · ${formatSeconds(transcription.processMs / 1000)} for ${formatSeconds(transcription.audioSeconds)} of audio` : ''}
+				</div>
+			)}
+
+			{enabled && phase === 'diarizing' && (
+				<div style={{ marginTop: 6, color: theme.secondaryText }}>
+					🗣️ {STAGE_LABEL[diarization.stage ?? ''] ?? 'Identifying speakers'}
+					{diarization.total > 0 ? ` ${diarization.done}/${diarization.total}` : ''}…
+					{diarization.total > 0 && (
+						<div style={{ height: 6, borderRadius: 3, backgroundColor: theme.backgroundSecondary, overflow: 'hidden', marginTop: 6 }}>
+							<div style={{ width: `${Math.min(100, (diarization.done / diarization.total) * 100)}%`, height: '100%', backgroundColor: theme.text, transition: 'width 0.2s' }} />
+						</div>
+					)}
+				</div>
+			)}
+
+			{enabled && phase === 'finalizing' && (
+				<div style={{ marginTop: 6, color: theme.secondaryText }}>
+					🗣️ {diarization.speakers !== null ? `${diarization.speakers} speaker${diarization.speakers === 1 ? '' : 's'} found` : 'No speaker labels'}
+					{diarization.ms !== null ? ` in ${formatSeconds(diarization.ms / 1000)}` : ''} · transcript sent, Claude is writing the summary…
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default OnDevicePanel

--- a/frontend/src/components/OnDevicePanel.tsx
+++ b/frontend/src/components/OnDevicePanel.tsx
@@ -180,7 +180,7 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 			{enabled && phase === 'diarizing' && (
 				<div style={{ marginTop: 6, color: theme.secondaryText }}>
 					🗣️ {STAGE_LABEL[diarization.stage ?? ''] ?? 'Identifying speakers'}
-					{diarization.total > 0 ? ` ${diarization.done}/${diarization.total}` : ''}…
+					{diarization.total > 0 ? ` ${Math.min(100, Math.round((diarization.done / diarization.total) * 100))}%` : ''}…
 					{diarization.total > 0 && (
 						<div style={{ height: 6, borderRadius: 3, backgroundColor: theme.backgroundSecondary, overflow: 'hidden', marginTop: 6 }}>
 							<div style={{ width: `${Math.min(100, (diarization.done / diarization.total) * 100)}%`, height: '100%', backgroundColor: theme.text, transition: 'width 0.2s' }} />

--- a/frontend/src/components/OnDevicePanel.tsx
+++ b/frontend/src/components/OnDevicePanel.tsx
@@ -59,8 +59,10 @@ const OnDevicePanel: React.FC<OnDevicePanelProps> = ({ controller, theme, locked
 		if (phase === 'error') return { icon: '❌', text: error ?? 'Failed' }
 		if (phase === 'fallback') return { icon: '↩️', text: `Handed over to the server${error ? ` (${error})` : ''}` }
 		if (phase === 'loading') {
-			const downloading = download && !download.done && download.total > 0 && download.loaded < download.total
-			if (downloading) return { icon: '⬇️', text: `Downloading Parakeet ${formatBytes(download.loaded)} / ${formatBytes(download.total)} · ${formatBytes(download.bytesPerSec)}/s${downloadEta !== null ? ` · ~${formatSeconds(downloadEta)} left` : ''}` }
+			if (download && !download.done) {
+				const known = download.total > download.loaded
+				return { icon: '⬇️', text: `Downloading Parakeet ${formatBytes(download.loaded)}${known ? ` / ${formatBytes(download.total)}` : ''} · ${formatBytes(download.bytesPerSec)}/s${downloadEta !== null && known ? ` · ~${formatSeconds(downloadEta)} left` : ''}` }
+			}
 			const since = download?.doneAt ?? download?.startedAt ?? null
 			const elapsed = since ? ` · ${formatSeconds((Date.now() - since) / 1000)}` : ''
 			const slow = since && Date.now() - since > 120_000 ? ' — taking long; if it never finishes the model may not fit in memory (try the CPU plan, or turn the switch off to record via the server)' : ''

--- a/frontend/src/components/OnDeviceStats.tsx
+++ b/frontend/src/components/OnDeviceStats.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { AppTheme } from '../styles/theme'
+import { formatBytes } from './OnDevicePanel'
+
+/** What the browser measured for an on-device meeting (meeting.client_stats). */
+export interface ClientStats {
+	plan?: string | null
+	backend?: 'webgpu' | 'wasm' | null
+	threads?: number | null
+	download?: { bytes: number; ms: number; cached: boolean } | null
+	model_load_ms?: number | null
+	transcription?: { chunks: number; audio_seconds: number; process_ms: number } | null
+	diarization?: { audio_seconds: number; ms: number | null; speakers: number | null; model_bytes: number | null; model_load_ms: number | null } | null
+	device?: { cores?: number | null; memory_gb?: number | null; mobile?: boolean | null } | null
+}
+
+const fmt = (ms: number) => (ms >= 60_000 ? `${Math.floor(ms / 60_000)}m ${Math.round((ms % 60_000) / 1000)}s` : `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`)
+
+const OnDeviceStats: React.FC<{ stats: ClientStats; theme: AppTheme }> = ({ stats, theme }) => {
+	const parts: string[] = []
+	if (stats.backend) parts.push(stats.backend === 'webgpu' ? 'GPU fp16' : `CPU int8 · ${stats.threads ?? 1} thr`)
+	if (stats.download) parts.push(stats.download.cached ? 'model cached' : `downloaded ${formatBytes(stats.download.bytes)} in ${fmt(stats.download.ms)}`)
+	if (typeof stats.model_load_ms === 'number') parts.push(`loaded in ${fmt(stats.model_load_ms)}`)
+	if (stats.transcription && stats.transcription.process_ms > 0) {
+		const speed = stats.transcription.audio_seconds / (stats.transcription.process_ms / 1000)
+		parts.push(`transcribed ${speed.toFixed(1)}× realtime`)
+	}
+	if (stats.diarization && typeof stats.diarization.ms === 'number') {
+		const speed = stats.diarization.audio_seconds / (stats.diarization.ms / 1000)
+		parts.push(`speakers in ${fmt(stats.diarization.ms)} (${speed.toFixed(1)}×)`)
+	}
+	if (parts.length === 0) return null
+	return (
+		<div style={{ fontSize: '12px', color: theme.secondaryText, marginTop: 6, lineHeight: 1.5 }} title="Measured in the browser that recorded this meeting">
+			⚡ On-device · {parts.join(' · ')}
+		</div>
+	)
+}
+
+export default OnDeviceStats

--- a/frontend/src/hooks/useMeetingSummary.ts
+++ b/frontend/src/hooks/useMeetingSummary.ts
@@ -4,6 +4,7 @@ import { getHistory, saveMeeting } from '../utils/history'
 import { SummaryLength } from '../contexts/SummaryLengthContext'
 import { SummaryLanguageState } from '../contexts/SummaryLanguageContext'
 import { apiUrl } from '../utils/api'
+import type { ClientStats } from '../components/OnDeviceStats'
 
 interface UseMeetingSummaryProps {
 	mid: string | undefined
@@ -29,6 +30,7 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 	const [canRediarize, setCanRediarize] = useState(false)
 	const [diarizationAttempted, setDiarizationAttempted] = useState(true)
 	const [speakerCount, setSpeakerCount] = useState<number | null>(null)
+	const [clientStats, setClientStats] = useState<ClientStats | null>(null)
 	const [processingStage, setProcessingStage] = useState<string | null>(null)
 	const [processingTotal, setProcessingTotal] = useState<number | null>(null)
 
@@ -63,6 +65,11 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 				setCanRediarize(!!data.can_rediarize)
 				setDiarizationAttempted(!!data.diarization_attempted)
 				setSpeakerCount(typeof data.speaker_count === 'number' ? data.speaker_count : null)
+				try {
+					setClientStats(data.client_stats ? (JSON.parse(data.client_stats) as ClientStats) : null)
+				} catch {
+					setClientStats(null)
+				}
 				setProcessingStage(data.processing_stage ?? null)
 				setProcessingTotal(typeof data.processing_total === 'number' ? data.processing_total : null)
 				const trn = data.transcript_text || null
@@ -308,6 +315,7 @@ export const useMeetingSummary = ({ mid, languageState, setLanguageState }: UseM
 		canRediarize,
 		diarizationAttempted,
 		speakerCount,
+		clientStats,
 		processingStage,
 		processingTotal,
 		handleRediarize,

--- a/frontend/src/hooks/useRecording.ts
+++ b/frontend/src/hooks/useRecording.ts
@@ -5,10 +5,11 @@ import { saveMeeting } from '../utils/history'
 import { AudioSource } from '../types'
 import { SummaryLanguageState } from '../contexts/SummaryLanguageContext'
 import { apiUrl } from '../utils/api'
+import type { OnDeviceController } from '../ondevice/useOnDevice'
 
 const CHUNK_DURATION_MS = 30_000
 
-export const useRecording = (summaryLength: SummaryLength, languageState: SummaryLanguageState) => {
+export const useRecording = (summaryLength: SummaryLength, languageState: SummaryLanguageState, onDevice: OnDeviceController | null = null) => {
 	const navigate = useNavigate()
 	const [isRecording, setRecording] = useState(false)
 	const [isProcessing, setIsProcessing] = useState(false)
@@ -30,6 +31,8 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 	const wakeLockSentinelRef = useRef<WakeLockSentinel | null>(null)
 
 	const meetingId = useRef<string | null>(null)
+	// True while the current meeting is transcribed/diarized in the browser.
+	const onDeviceActiveRef = useRef(false)
 	const mediaRef = useRef<MediaRecorder | null>(null)
 	const streamRef = useRef<MediaStream | null>(null)
 	const displayStreamRef = useRef<MediaStream | null>(null)
@@ -92,6 +95,7 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 		setProcessingTotal(null)
 		chunkIndexRef.current = 0
 		meetingId.current = null
+		onDeviceActiveRef.current = false
 		setWakeLockStatus('inactive')
 		setIsPaused(false)
 		isPausedRef.current = false
@@ -141,6 +145,7 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 	const createMeetingOnBackend = useCallback(
 		async (title: string, context: string) => {
 			const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+			const useOnDeviceNow = !!onDevice?.isUsable
 			const res = await fetch(apiUrl(`/api/meetings`), {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -151,15 +156,18 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 					summary_custom_language: languageState.lastCustomLanguage,
 					context: context,
 					timezone: timezone,
+					client_processing: useOnDeviceNow,
 				}),
 			})
 			if (!res.ok) throw new Error('Failed to create meeting')
 			const data = await res.json()
 			meetingId.current = data.id
+			onDeviceActiveRef.current = useOnDeviceNow
+			if (useOnDeviceNow) onDevice?.beginMeeting(data.id)
 			saveMeeting({ id: data.id, title, started_at: new Date().toISOString(), status: 'pending' })
 			return data.id
 		},
-		[summaryLength, languageState],
+		[summaryLength, languageState, onDevice],
 	)
 
 	const uploadChunk = useCallback(async (blob: Blob, index: number, isFinal = false) => {
@@ -260,9 +268,16 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 				await new Promise((resolve) => setTimeout(resolve, 500))
 				const finalBlob = new Blob([], { type: mediaRef.current?.mimeType || 'audio/webm' })
 				await uploadChunk(finalBlob, chunkIndexRef.current, true)
+
+				// On-device: wait for the last chunks, identify speakers and
+				// hand the transcript over. Polling then sees the summary
+				// exactly as it would for a server-processed meeting.
+				if (onDeviceActiveRef.current && onDevice) {
+					await onDevice.finish()
+				}
 			}
 		},
-		[uploadChunk],
+		[uploadChunk, onDevice],
 	)
 
 	const pauseRecording = useCallback(() => {
@@ -378,7 +393,9 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 					mediaRef.current = recorder
 					recorder.ondataavailable = (e) => {
 						if (e.data.size > 0) {
-							uploadChunk(e.data, chunkIndexRef.current++)
+							const index = chunkIndexRef.current++
+							uploadChunk(e.data, index)
+							if (onDeviceActiveRef.current) onDevice?.addChunk(e.data, index)
 							setLocalChunksCount((c) => c + 1)
 						}
 					}
@@ -403,7 +420,7 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 				resetState()
 			}
 		},
-		[createMeetingOnBackend, includeMic, pollMeetingStatus, stopRecording, uploadChunk],
+		[createMeetingOnBackend, includeMic, pollMeetingStatus, stopRecording, uploadChunk, onDevice],
 	)
 
 	const startFileProcessing = useCallback(
@@ -509,8 +526,8 @@ export const useRecording = (summaryLength: SummaryLength, languageState: Summar
 		resumeRecording,
 		startFileProcessing,
 		transcriptionSpeedLabel,
-		processingStage,
-		processingTotal,
+		processingStage: onDevice?.localStage ?? processingStage,
+		processingTotal: onDevice?.localStage ? 2 : processingTotal,
 		analyserRef,
 		animationFrameRef,
 		updateContext,

--- a/frontend/src/ondevice/api.ts
+++ b/frontend/src/ondevice/api.ts
@@ -1,0 +1,51 @@
+/** Backend calls specific to on-device meetings. */
+import { apiUrl } from '../utils/api'
+import type { TranscriptSegment } from './diarization/label'
+
+export interface ModelManifest {
+	segmentation: { url: string; name: string; bytes: number }
+	embedding: { url: string; name: string; bytes: number }
+	config: {
+		window_shift_ratio: number
+		cluster_threshold: number
+		min_speaker_share: number
+		min_duration_on: number
+		min_duration_off: number
+	}
+}
+
+export async function fetchModelManifest(): Promise<ModelManifest> {
+	const res = await fetch(apiUrl('/api/models'))
+	if (!res.ok) {
+		const detail = await res.json().catch(() => ({}))
+		throw new Error(detail.detail || `Could not fetch model list (HTTP ${res.status})`)
+	}
+	const manifest = (await res.json()) as ModelManifest
+	// The worker fetches these itself, so they must be absolute for a
+	// cross-origin API base.
+	manifest.segmentation.url = apiUrl(manifest.segmentation.url)
+	manifest.embedding.url = apiUrl(manifest.embedding.url)
+	return manifest
+}
+
+export async function putChunkTranscript(meetingId: string, index: number, text: string, segments: TranscriptSegment[], audioSeconds: number): Promise<void> {
+	const res = await fetch(apiUrl(`/api/meetings/${meetingId}/chunks/${index}/transcript`), {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ text, segments, audio_seconds: audioSeconds }),
+	})
+	if (!res.ok) throw new Error(`Chunk ${index}: HTTP ${res.status}`)
+}
+
+export async function finalizeMeeting(meetingId: string, body: { transcript: string; speaker_count: number | null; duration_seconds: number; client_stats: unknown }): Promise<void> {
+	const res = await fetch(apiUrl(`/api/meetings/${meetingId}/finalize`), {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+	if (!res.ok) throw new Error(`Finalize: HTTP ${res.status}`)
+}
+
+export async function requestServerFallback(meetingId: string): Promise<void> {
+	await fetch(apiUrl(`/api/meetings/${meetingId}/client-fallback`), { method: 'POST' })
+}

--- a/frontend/src/ondevice/capabilities.ts
+++ b/frontend/src/ondevice/capabilities.ts
@@ -1,0 +1,88 @@
+/**
+ * What this device can realistically run. Decides between the two Parakeet
+ * plans and produces the warnings shown next to the toggle:
+ *
+ *   gpu-fp16 — encoder on WebGPU in fp16 (~1.2 GB download), decoder on WASM.
+ *   cpu-int8 — everything on WASM with an int8 encoder (~0.6 GB download).
+ *
+ * Nothing here is fatal: the user can always try, and a failed model load
+ * hands the meeting back to the server (see useOnDevice).
+ */
+
+export type ParakeetPlan = 'gpu-fp16' | 'cpu-int8'
+export type PlanChoice = 'auto' | ParakeetPlan
+
+export interface DeviceCapabilities {
+	webgpu: boolean
+	fp16: boolean
+	crossOriginIsolated: boolean
+	cores: number
+	/** Chrome's navigator.deviceMemory, capped by the browser at 8. null elsewhere. */
+	memoryGb: number | null
+	isIOS: boolean
+	isMobile: boolean
+	recommended: ParakeetPlan
+	warnings: string[]
+}
+
+export const PLAN_DOWNLOAD_BYTES: Record<ParakeetPlan, number> = {
+	// encoder fp16 ≈ 1.2 GB + decoder int8 + tokenizer
+	'gpu-fp16': 1.25e9,
+	// encoder int8 ≈ 0.62 GB + decoder int8 + tokenizer
+	'cpu-int8': 0.65e9,
+}
+
+export const PLAN_LABELS: Record<ParakeetPlan, string> = {
+	'gpu-fp16': 'GPU · fp16 · ~1.2 GB',
+	'cpu-int8': 'CPU · int8 · ~0.6 GB',
+}
+
+const isIOSDevice = () => /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+
+export async function detectCapabilities(): Promise<DeviceCapabilities> {
+	let webgpu = false
+	let fp16 = false
+	const gpu = (navigator as unknown as { gpu?: { requestAdapter(): Promise<{ features: Set<string> } | null> } }).gpu
+	if (gpu) {
+		try {
+			const adapter = await gpu.requestAdapter()
+			if (adapter) {
+				webgpu = true
+				fp16 = adapter.features.has('shader-f16')
+			}
+		} catch {
+			webgpu = false
+		}
+	}
+	const crossOriginIsolated = typeof SharedArrayBuffer !== 'undefined' && (window as unknown as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
+	const cores = navigator.hardwareConcurrency || 2
+	const memoryGb = (navigator as unknown as { deviceMemory?: number }).deviceMemory ?? null
+	const isIOS = isIOSDevice()
+	const isMobile = isIOS || /Android|Mobile/i.test(navigator.userAgent)
+
+	const warnings: string[] = []
+	if (isIOS) {
+		warnings.push('iPhone/iPad: Safari gives a tab far less memory than the ~1.5 GB Parakeet needs. Expect this to fail or crash the tab; the server will take over if it does.')
+	} else if (isMobile) {
+		warnings.push('Phone detected: needs ~1.5 GB free RAM and will be slow. Keep the screen on — a backgrounded tab stops processing.')
+	}
+	if (!webgpu) {
+		warnings.push('No WebGPU in this browser: Parakeet will run on the CPU (WASM), roughly 3–5× slower than on a GPU.')
+	} else if (!fp16) {
+		warnings.push('Your GPU has no fp16 support; using the CPU int8 model instead.')
+	}
+	if (!crossOriginIsolated) {
+		warnings.push('Page is not cross-origin isolated (missing COOP/COEP headers): WASM runs single-threaded, so CPU work is slower.')
+	}
+	if (memoryGb !== null && memoryGb < 4) {
+		warnings.push(`Only ~${memoryGb} GB RAM reported; the model may not fit.`)
+	}
+
+	const recommended: ParakeetPlan = webgpu && fp16 && !isIOS ? 'gpu-fp16' : 'cpu-int8'
+	return { webgpu, fp16, crossOriginIsolated, cores, memoryGb, isIOS, isMobile, recommended, warnings }
+}
+
+export function resolvePlan(choice: PlanChoice, caps: DeviceCapabilities | null): ParakeetPlan {
+	if (choice !== 'auto') return choice
+	return caps?.recommended ?? 'cpu-int8'
+}

--- a/frontend/src/ondevice/capabilities.ts
+++ b/frontend/src/ondevice/capabilities.ts
@@ -2,8 +2,12 @@
  * What this device can realistically run. Decides between the two Parakeet
  * plans and produces the warnings shown next to the toggle:
  *
- *   gpu-fp16 — encoder on WebGPU in fp16 (~1.2 GB download), decoder on WASM.
- *   cpu-int8 — everything on WASM with an int8 encoder (~0.6 GB download).
+ *   gpu-fp16 — encoder on WebGPU, decoder on WASM.
+ *   cpu-int8 — everything on WASM, with the int8 encoder.
+ *
+ * Download sizes are not listed here: they depend on which files
+ * VITE_PARAKEET_MODEL_BASE points at, so the panel asks the host instead
+ * (see measurePlanBytes in hub.ts).
  *
  * Nothing here is fatal: the user can always try, and a failed model load
  * hands the meeting back to the server (see useOnDevice).
@@ -25,16 +29,9 @@ export interface DeviceCapabilities {
 	warnings: string[]
 }
 
-export const PLAN_DOWNLOAD_BYTES: Record<ParakeetPlan, number> = {
-	// encoder fp16 ≈ 1.2 GB + decoder int8 + tokenizer
-	'gpu-fp16': 1.25e9,
-	// encoder int8 ≈ 0.62 GB + decoder int8 + tokenizer
-	'cpu-int8': 0.65e9,
-}
-
 export const PLAN_LABELS: Record<ParakeetPlan, string> = {
-	'gpu-fp16': 'GPU · fp16 · ~1.2 GB',
-	'cpu-int8': 'CPU · int8 · ~0.6 GB',
+	'gpu-fp16': 'GPU',
+	'cpu-int8': 'CPU',
 }
 
 const isIOSDevice = () => /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)

--- a/frontend/src/ondevice/diarization.worker.ts
+++ b/frontend/src/ondevice/diarization.worker.ts
@@ -1,0 +1,85 @@
+/// <reference lib="webworker" />
+/**
+ * Web Worker: speaker diarization on this device.
+ *
+ * Loads the pyannote segmentation + campplus embedding models served by the
+ * backend (/api/models/…) into ONNX Runtime Web (WASM) and runs the sherpa
+ * port in ./diarization/pipeline.ts. Both models are small (~36 MB together)
+ * and int8/fp32 CPU models, so WASM is the right backend for them.
+ */
+import { configureOrt, ort } from './ortSetup'
+import { diarize, DEFAULT_DIARIZATION_CONFIG, type DiarizationConfig, type DiarizationModels, type DiarizationProgress } from './diarization/pipeline'
+import type { SpeakerTurn } from './diarization/label'
+
+export type DiarizationWorkerRequest =
+	| { type: 'load'; segmentationUrl: string; embeddingUrl: string }
+	| { type: 'run'; audio: Float32Array; config: Partial<DiarizationConfig> }
+
+export type DiarizationWorkerResponse =
+	| { type: 'loaded'; loadMs: number; downloadBytes: number; threads: number }
+	| { type: 'progress'; progress: DiarizationProgress }
+	| { type: 'result'; turns: SpeakerTurn[]; ms: number }
+	| { type: 'error'; message: string }
+
+const post = (msg: DiarizationWorkerResponse) => self.postMessage(msg)
+
+let models: DiarizationModels | null = null
+
+async function fetchBytes(url: string): Promise<ArrayBuffer> {
+	const res = await fetch(url)
+	if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`)
+	return res.arrayBuffer()
+}
+
+async function load(segmentationUrl: string, embeddingUrl: string) {
+	const { threads } = configureOrt()
+	const t0 = performance.now()
+	const [segBytes, embBytes] = await Promise.all([fetchBytes(segmentationUrl), fetchBytes(embeddingUrl)])
+	const opts: ort.InferenceSession.SessionOptions = { executionProviders: ['wasm'], graphOptimizationLevel: 'all' }
+	const [seg, emb] = await Promise.all([
+		ort.InferenceSession.create(new Uint8Array(segBytes), opts),
+		ort.InferenceSession.create(new Uint8Array(embBytes), opts),
+	])
+	const segIn = seg.inputNames[0]
+	const segOut = seg.outputNames[0]
+	const embIn = emb.inputNames[0]
+	const embOut = emb.outputNames[0]
+
+	models = {
+		async segment(window) {
+			const out = await seg.run({ [segIn]: new ort.Tensor('float32', window, [1, 1, window.length]) })
+			const y = out[segOut]
+			return { data: y.data as Float32Array, frames: Number(y.dims[1]) }
+		},
+		async embed(features, frames) {
+			const out = await emb.run({ [embIn]: new ort.Tensor('float32', features, [1, frames, 80]) })
+			return out[embOut].data as Float32Array
+		},
+	}
+	post({ type: 'loaded', loadMs: performance.now() - t0, downloadBytes: segBytes.byteLength + embBytes.byteLength, threads })
+}
+
+async function run(audio: Float32Array, config: Partial<DiarizationConfig>) {
+	if (!models) throw new Error('Diarization models are not loaded')
+	const t0 = performance.now()
+	let lastPost = 0
+	const turns = await diarize(audio, models, { ...DEFAULT_DIARIZATION_CONFIG, ...config }, (progress) => {
+		// Throttle: embedding reports per segment, which can be thousands.
+		const now = performance.now()
+		if (now - lastPost > 150 || progress.done === progress.total) {
+			lastPost = now
+			post({ type: 'progress', progress })
+		}
+	})
+	post({ type: 'result', turns, ms: performance.now() - t0 })
+}
+
+self.onmessage = async (event: MessageEvent<DiarizationWorkerRequest>) => {
+	const msg = event.data
+	try {
+		if (msg.type === 'load') await load(msg.segmentationUrl, msg.embeddingUrl)
+		else if (msg.type === 'run') await run(msg.audio, msg.config)
+	} catch (err) {
+		post({ type: 'error', message: err instanceof Error ? err.message : String(err) })
+	}
+}

--- a/frontend/src/ondevice/diarization.worker.ts
+++ b/frontend/src/ondevice/diarization.worker.ts
@@ -7,7 +7,7 @@
  * port in ./diarization/pipeline.ts. Both models are small (~36 MB together)
  * and int8/fp32 CPU models, so WASM is the right backend for them.
  */
-import { configureOrt, ort } from './ortSetup'
+import { configureOrt, isOrtHelperWorker, ort } from './ortSetup'
 import { diarize, DEFAULT_DIARIZATION_CONFIG, type DiarizationConfig, type DiarizationModels, type DiarizationProgress } from './diarization/pipeline'
 import type { SpeakerTurn } from './diarization/label'
 
@@ -74,12 +74,16 @@ async function run(audio: Float32Array, config: Partial<DiarizationConfig>) {
 	post({ type: 'result', turns, ms: performance.now() - t0 })
 }
 
-self.onmessage = async (event: MessageEvent<DiarizationWorkerRequest>) => {
-	const msg = event.data
-	try {
-		if (msg.type === 'load') await load(msg.segmentationUrl, msg.embeddingUrl)
-		else if (msg.type === 'run') await run(msg.audio, msg.config)
-	} catch (err) {
-		post({ type: 'error', message: err instanceof Error ? err.message : String(err) })
+// An ORT pthread may evaluate this file too (see isOrtHelperWorker); it must
+// not take over the message handler.
+if (!isOrtHelperWorker()) {
+	self.onmessage = async (event: MessageEvent<DiarizationWorkerRequest>) => {
+		const msg = event.data
+		try {
+			if (msg.type === 'load') await load(msg.segmentationUrl, msg.embeddingUrl)
+			else if (msg.type === 'run') await run(msg.audio, msg.config)
+		} catch (err) {
+			post({ type: 'error', message: err instanceof Error ? err.message : String(err) })
+		}
 	}
 }

--- a/frontend/src/ondevice/diarization/cluster.ts
+++ b/frontend/src/ondevice/diarization/cluster.ts
@@ -1,0 +1,108 @@
+/**
+ * Agglomerative clustering with complete linkage over cosine distance, cut at a
+ * distance threshold — the same procedure as sherpa-onnx's FastClustering
+ * (which wraps fastcluster's hclust_fast + cutree_cdist).
+ *
+ * Implemented with the nearest-neighbour-chain algorithm, so it is O(n²) in
+ * time and memory rather than the O(n³) of the textbook version. An hour of
+ * audio yields a couple of thousand embeddings, which is comfortably fast.
+ */
+
+/** Labels every row of `embeddings` (row-major, `dim` wide) with a cluster id. */
+export function clusterEmbeddings(embeddings: Float32Array, rows: number, dim: number, threshold: number): Int32Array {
+	if (rows <= 0) return new Int32Array(0)
+	if (rows === 1) return new Int32Array([0])
+
+	// L2-normalise rows so the dot product is the cosine similarity.
+	const unit = new Float32Array(embeddings)
+	for (let i = 0; i < rows; i++) {
+		let norm = 0
+		for (let d = 0; d < dim; d++) norm += unit[i * dim + d] * unit[i * dim + d]
+		norm = Math.sqrt(norm) || 1
+		for (let d = 0; d < dim; d++) unit[i * dim + d] /= norm
+	}
+
+	// Full distance matrix, d = max(0, 1 - cos).
+	const dist = new Float64Array(rows * rows)
+	for (let i = 0; i < rows; i++) {
+		for (let j = i + 1; j < rows; j++) {
+			let dot = 0
+			for (let d = 0; d < dim; d++) dot += unit[i * dim + d] * unit[j * dim + d]
+			const v = Math.max(0, 1 - dot)
+			dist[i * rows + j] = v
+			dist[j * rows + i] = v
+		}
+	}
+
+	// Union-find over merges below the threshold. Complete linkage is
+	// monotone, so cutting by merge height is a valid dendrogram cut.
+	const parent = new Int32Array(rows)
+	for (let i = 0; i < rows; i++) parent[i] = i
+	const find = (x: number): number => {
+		while (parent[x] !== x) {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+
+	const active = new Uint8Array(rows).fill(1)
+	let remaining = rows
+	const chain: number[] = []
+
+	while (remaining > 1) {
+		if (chain.length === 0) {
+			let seed = 0
+			while (!active[seed]) seed++
+			chain.push(seed)
+		}
+		let a = chain[chain.length - 1]
+		// Walk to a reciprocal nearest-neighbour pair.
+		for (;;) {
+			let best = -1
+			let bestDist = Infinity
+			const prev = chain.length >= 2 ? chain[chain.length - 2] : -1
+			for (let j = 0; j < rows; j++) {
+				if (j === a || !active[j]) continue
+				const d = dist[a * rows + j]
+				// Prefer the previous chain element on ties so the chain terminates.
+				if (d < bestDist || (d === bestDist && j === prev)) {
+					bestDist = d
+					best = j
+				}
+			}
+			if (best === prev) {
+				chain.pop()
+				chain.pop()
+				// Merge `a` and `best` at height bestDist (complete linkage:
+				// new distance to any k is the max of the two old ones).
+				if (bestDist < threshold) parent[find(best)] = find(a)
+				for (let k = 0; k < rows; k++) {
+					if (!active[k] || k === a || k === best) continue
+					const merged = Math.max(dist[a * rows + k], dist[best * rows + k])
+					dist[a * rows + k] = merged
+					dist[k * rows + a] = merged
+				}
+				active[best] = 0
+				remaining--
+				break
+			}
+			chain.push(best)
+			a = best
+		}
+	}
+
+	// Compact roots into 0..K-1 in order of first appearance.
+	const labels = new Int32Array(rows)
+	const ids = new Map<number, number>()
+	for (let i = 0; i < rows; i++) {
+		const root = find(i)
+		let id = ids.get(root)
+		if (id === undefined) {
+			id = ids.size
+			ids.set(root, id)
+		}
+		labels[i] = id
+	}
+	return labels
+}

--- a/frontend/src/ondevice/diarization/fbank.ts
+++ b/frontend/src/ondevice/diarization/fbank.ts
@@ -1,0 +1,176 @@
+/**
+ * Kaldi-compatible log-mel filterbank features, as computed by kaldi-native-fbank
+ * inside sherpa-onnx for the speaker-embedding model.
+ *
+ * The parameters below are sherpa's FeatureExtractorConfig defaults, which the
+ * server-side diarization (backend/app/diarization.py) uses implicitly:
+ * 25 ms Povey window, 10 ms shift, 80 mel bins from 20 Hz to Nyquist-400 Hz,
+ * DC removal, 0.97 pre-emphasis, no dither, snip_edges=false (frames are
+ * centred and the edges reflected). Samples stay in [-1, 1] because the
+ * campplus model declares normalize_samples=1.
+ */
+
+export const SAMPLE_RATE = 16_000
+export const NUM_MEL_BINS = 80
+const FRAME_LENGTH = 400 // 25 ms
+const FRAME_SHIFT = 160 // 10 ms
+const FFT_SIZE = 512 // frame length rounded up to a power of two
+const LOW_FREQ = 20
+const HIGH_FREQ = SAMPLE_RATE / 2 - 400
+const PREEMPH = 0.97
+const LOG_FLOOR = 1.1920928955078125e-7 // std::numeric_limits<float>::epsilon()
+
+const melScale = (hz: number) => 1127 * Math.log(1 + hz / 700)
+
+/** Povey window: Hann raised to 0.85. */
+const WINDOW = (() => {
+	const w = new Float32Array(FRAME_LENGTH)
+	for (let i = 0; i < FRAME_LENGTH; i++) {
+		w[i] = Math.pow(0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (FRAME_LENGTH - 1)), 0.85)
+	}
+	return w
+})()
+
+/**
+ * Kaldi mel banks: triangular filters on the mel scale, evaluated at the FFT
+ * bin centres (bins 0..FFT_SIZE/2-1; Kaldi never uses the Nyquist bin).
+ * Stored sparsely as [firstBin, weights] per mel bin.
+ */
+const MEL_BANKS = (() => {
+	const numFftBins = FFT_SIZE / 2
+	const fftBinWidth = SAMPLE_RATE / FFT_SIZE
+	const melLow = melScale(LOW_FREQ)
+	const melHigh = melScale(HIGH_FREQ)
+	const melDelta = (melHigh - melLow) / (NUM_MEL_BINS + 1)
+	const banks: { offset: number; weights: Float32Array }[] = []
+	for (let bin = 0; bin < NUM_MEL_BINS; bin++) {
+		const left = melLow + bin * melDelta
+		const center = left + melDelta
+		const right = left + 2 * melDelta
+		const weights = new Float32Array(numFftBins)
+		let first = -1
+		let last = -1
+		for (let k = 0; k < numFftBins; k++) {
+			const mel = melScale(k * fftBinWidth)
+			if (mel > left && mel < right) {
+				weights[k] = mel <= center ? (mel - left) / (center - left) : (right - mel) / (right - center)
+				if (first < 0) first = k
+				last = k
+			}
+		}
+		banks.push({ offset: first, weights: weights.slice(first, last + 1) })
+	}
+	return banks
+})()
+
+// Precomputed bit-reversal permutation and twiddles for the radix-2 FFT.
+const BIT_REVERSE = (() => {
+	const table = new Uint16Array(FFT_SIZE)
+	const bits = Math.log2(FFT_SIZE)
+	for (let i = 0; i < FFT_SIZE; i++) {
+		let r = 0
+		for (let b = 0; b < bits; b++) r |= ((i >> b) & 1) << (bits - 1 - b)
+		table[i] = r
+	}
+	return table
+})()
+const TWIDDLE_COS = new Float64Array(FFT_SIZE / 2)
+const TWIDDLE_SIN = new Float64Array(FFT_SIZE / 2)
+for (let i = 0; i < FFT_SIZE / 2; i++) {
+	TWIDDLE_COS[i] = Math.cos((-2 * Math.PI * i) / FFT_SIZE)
+	TWIDDLE_SIN[i] = Math.sin((-2 * Math.PI * i) / FFT_SIZE)
+}
+
+/** In-place iterative radix-2 complex FFT over (re, im) of length FFT_SIZE. */
+function fft(re: Float64Array, im: Float64Array): void {
+	for (let i = 0; i < FFT_SIZE; i++) {
+		const j = BIT_REVERSE[i]
+		if (j > i) {
+			const tr = re[i]
+			re[i] = re[j]
+			re[j] = tr
+			const ti = im[i]
+			im[i] = im[j]
+			im[j] = ti
+		}
+	}
+	for (let size = 2; size <= FFT_SIZE; size <<= 1) {
+		const half = size >> 1
+		const step = FFT_SIZE / size
+		for (let start = 0; start < FFT_SIZE; start += size) {
+			for (let k = 0; k < half; k++) {
+				const wr = TWIDDLE_COS[k * step]
+				const wi = TWIDDLE_SIN[k * step]
+				const a = start + k
+				const b = a + half
+				const xr = re[b] * wr - im[b] * wi
+				const xi = re[b] * wi + im[b] * wr
+				re[b] = re[a] - xr
+				im[b] = im[a] - xi
+				re[a] += xr
+				im[a] += xi
+			}
+		}
+	}
+}
+
+/** Number of frames Kaldi produces for `n` samples with snip_edges=false. */
+export function numFrames(n: number): number {
+	return Math.floor((n + FRAME_SHIFT / 2) / FRAME_SHIFT)
+}
+
+/**
+ * Compute log-mel features for a 16 kHz mono signal.
+ * Returns a row-major (frames x 80) Float32Array.
+ */
+export function computeFbank(samples: Float32Array): { frames: number; data: Float32Array } {
+	const n = samples.length
+	const frames = numFrames(n)
+	const data = new Float32Array(frames * NUM_MEL_BINS)
+	const re = new Float64Array(FFT_SIZE)
+	const im = new Float64Array(FFT_SIZE)
+	const power = new Float64Array(FFT_SIZE / 2)
+	const frame = new Float64Array(FRAME_LENGTH)
+
+	for (let f = 0; f < frames; f++) {
+		// Centred frame with reflected edges, exactly as Kaldi's ExtractWindow.
+		const start = f * FRAME_SHIFT + FRAME_SHIFT / 2 - FRAME_LENGTH / 2
+		let mean = 0
+		for (let i = 0; i < FRAME_LENGTH; i++) {
+			let s = start + i
+			while (s < 0 || s >= n) s = s < 0 ? -s - 1 : 2 * n - 1 - s
+			frame[i] = samples[s]
+			mean += frame[i]
+		}
+		mean /= FRAME_LENGTH
+		for (let i = 0; i < FRAME_LENGTH; i++) frame[i] -= mean
+		for (let i = FRAME_LENGTH - 1; i > 0; i--) frame[i] -= PREEMPH * frame[i - 1]
+		frame[0] -= PREEMPH * frame[0]
+
+		re.fill(0)
+		im.fill(0)
+		for (let i = 0; i < FRAME_LENGTH; i++) re[i] = frame[i] * WINDOW[i]
+		fft(re, im)
+		for (let k = 0; k < FFT_SIZE / 2; k++) power[k] = re[k] * re[k] + im[k] * im[k]
+
+		const row = f * NUM_MEL_BINS
+		for (let bin = 0; bin < NUM_MEL_BINS; bin++) {
+			const { offset, weights } = MEL_BANKS[bin]
+			let energy = 0
+			for (let i = 0; i < weights.length; i++) energy += weights[i] * power[offset + i]
+			data[row + bin] = Math.log(Math.max(energy, LOG_FLOOR))
+		}
+	}
+	return { frames, data }
+}
+
+/** sherpa's "global-mean" feature normalisation: subtract the per-bin mean. */
+export function subtractGlobalMean(data: Float32Array, frames: number): void {
+	if (frames === 0) return
+	for (let bin = 0; bin < NUM_MEL_BINS; bin++) {
+		let sum = 0
+		for (let f = 0; f < frames; f++) sum += data[f * NUM_MEL_BINS + bin]
+		const mean = sum / frames
+		for (let f = 0; f < frames; f++) data[f * NUM_MEL_BINS + bin] -= mean
+	}
+}

--- a/frontend/src/ondevice/diarization/label.ts
+++ b/frontend/src/ondevice/diarization/label.ts
@@ -1,0 +1,141 @@
+/**
+ * Post-processing that lives in backend/app/diarization.py on the server,
+ * ported so the on-device path produces the identical labelled transcript:
+ * fold noise clusters into real speakers, renumber by first appearance, and
+ * attach a "Speaker N:" label to each transcript segment.
+ */
+
+export interface SpeakerTurn {
+	start: number
+	end: number
+	speaker: number
+}
+
+export interface TranscriptSegment {
+	start: number
+	end: number
+	text: string
+}
+
+export interface TranscriptChunk {
+	index: number
+	text: string
+	segments: TranscriptSegment[]
+	/** Absolute start of the chunk within the whole recording, seconds. */
+	offset: number | null
+}
+
+/**
+ * Fold away clusters holding less than `minShare` of the speech into their
+ * nearest real speaker. Same rule and reasoning as `_prune_minor_speakers`.
+ */
+export function pruneMinorSpeakers(turns: SpeakerTurn[], minShare: number): SpeakerTurn[] {
+	if (turns.length === 0) return turns
+	const talk = new Map<number, number>()
+	for (const t of turns) talk.set(t.speaker, (talk.get(t.speaker) ?? 0) + (t.end - t.start))
+	let total = 0
+	for (const s of talk.values()) total += s
+	total = total || 1
+
+	const major = new Set<number>()
+	for (const [speaker, seconds] of talk) if (seconds / total >= minShare) major.add(speaker)
+	if (major.size === 0 || major.size === talk.size) return turns
+
+	const majorTurns = turns.filter((t) => major.has(t.speaker))
+	if (majorTurns.length === 0) return turns
+
+	const nearestMajor = (turn: SpeakerTurn): number => {
+		let best = turn.speaker
+		let bestDistance = Infinity
+		for (const other of majorTurns) {
+			if (other.end >= turn.start && other.start <= turn.end) return other.speaker
+			const distance = Math.min(Math.abs(turn.start - other.end), Math.abs(other.start - turn.end))
+			if (distance < bestDistance) {
+				best = other.speaker
+				bestDistance = distance
+			}
+		}
+		return best
+	}
+
+	return turns.map((t) => (major.has(t.speaker) ? t : { start: t.start, end: t.end, speaker: nearestMajor(t) }))
+}
+
+/** Renumber so "Speaker 1" is whoever spoke first. Returns [turns, count]. */
+export function renumberByFirstAppearance(turns: SpeakerTurn[]): [SpeakerTurn[], number] {
+	const order = new Map<number, number>()
+	const out: SpeakerTurn[] = []
+	for (const t of turns) {
+		let id = order.get(t.speaker)
+		if (id === undefined) {
+			id = order.size + 1
+			order.set(t.speaker, id)
+		}
+		out.push({ start: t.start, end: t.end, speaker: id })
+	}
+	return [out, order.size]
+}
+
+/** The speaker whose turn overlaps [start, end] most, or null. Turns must be sorted by start. */
+function speakerFor(start: number, end: number, turns: SpeakerTurn[]): number | null {
+	let bestSpeaker: number | null = null
+	let bestOverlap = 0
+	for (const turn of turns) {
+		if (turn.end <= start) continue
+		if (turn.start >= end) break
+		const overlap = Math.min(end, turn.end) - Math.max(start, turn.start)
+		if (overlap > bestOverlap) {
+			bestSpeaker = turn.speaker
+			bestOverlap = overlap
+		}
+	}
+	return bestSpeaker
+}
+
+/** Build the "Speaker N: …" transcript. Mirrors `label_transcript` exactly. */
+export function labelTranscript(chunks: TranscriptChunk[], turns: SpeakerTurn[]): string {
+	const blocks: [number | null, string[]][] = []
+	const append = (speaker: number | null, text: string) => {
+		text = text.trim()
+		if (!text) return
+		const last = blocks[blocks.length - 1]
+		if (last && last[0] === speaker) last[1].push(text)
+		else blocks.push([speaker, [text]])
+	}
+
+	for (const chunk of chunks) {
+		if (chunk.offset === null || chunk.segments.length === 0) {
+			if (chunk.text) append(blocks.length ? blocks[blocks.length - 1][0] : null, chunk.text)
+			continue
+		}
+		for (const seg of chunk.segments) {
+			const text = seg.text.trim()
+			if (!text) continue
+			const start = chunk.offset + seg.start
+			const end = chunk.offset + seg.end
+			let speaker = speakerFor(start, end, turns)
+			if (speaker === null) speaker = blocks.length ? blocks[blocks.length - 1][0] : null
+			append(speaker, text)
+		}
+	}
+
+	// Speech before the first detected turn belongs to whoever spoke first.
+	const firstKnown = blocks.find((b) => b[0] !== null)?.[0] ?? null
+	if (firstKnown !== null) {
+		for (const block of blocks) {
+			if (block[0] !== null) break
+			block[0] = firstKnown
+		}
+	}
+
+	const coalesced: [number | null, string[]][] = []
+	for (const [speaker, parts] of blocks) {
+		const last = coalesced[coalesced.length - 1]
+		if (last && last[0] === speaker) last[1].push(...parts)
+		else coalesced.push([speaker, [...parts]])
+	}
+
+	return coalesced
+		.map(([speaker, parts]) => `${speaker !== null ? `Speaker ${speaker}` : 'Unknown speaker'}: ${parts.join(' ')}`)
+		.join('\n\n')
+}

--- a/frontend/src/ondevice/diarization/pipeline.ts
+++ b/frontend/src/ondevice/diarization/pipeline.ts
@@ -1,0 +1,432 @@
+/**
+ * Speaker diarization, ported step for step from sherpa-onnx's
+ * OfflineSpeakerDiarizationPyannoteImpl so that running it in the browser
+ * gives the same speaker turns the server would.
+ *
+ * Stages: slide a 10 s window over the audio and run pyannote segmentation
+ * (3 local speakers per window, powerset-encoded) → per window and local
+ * speaker, gather the frames where only that speaker talks and embed them
+ * with campplus → cluster the embeddings across windows → relabel each
+ * window's local speakers with their cluster → vote per frame → turns.
+ *
+ * The ONNX sessions are injected so this file has no runtime dependency; the
+ * worker supplies onnxruntime-web and the test harness onnxruntime-node.
+ */
+
+import { computeFbank, subtractGlobalMean } from './fbank'
+import { clusterEmbeddings } from './cluster'
+import type { SpeakerTurn } from './label'
+
+export interface DiarizationModels {
+	/** Runs segmentation on one window (1, 1, windowSize). Returns (frames x numClasses). */
+	segment(window: Float32Array): Promise<{ data: Float32Array; frames: number }>
+	/** Runs the embedding model on (1, frames, 80) features. Returns the embedding vector. */
+	embed(features: Float32Array, frames: number): Promise<Float32Array>
+}
+
+export interface DiarizationConfig {
+	/** Metadata baked into the segmentation model. */
+	windowSize: number
+	receptiveFieldSize: number
+	receptiveFieldShift: number
+	numSpeakers: number
+	numClasses: number
+	powersetMaxClasses: number
+	sampleRate: number
+	/** Tunables, mirroring backend/app/config.py. */
+	windowShiftRatio: number
+	clusterThreshold: number
+	minDurationOn: number
+	minDurationOff: number
+}
+
+/** sherpa-onnx-pyannote-segmentation-3-0 + the backend's tuned defaults. */
+export const DEFAULT_DIARIZATION_CONFIG: DiarizationConfig = {
+	windowSize: 160_000,
+	receptiveFieldSize: 991,
+	receptiveFieldShift: 270,
+	numSpeakers: 3,
+	numClasses: 7,
+	powersetMaxClasses: 2,
+	sampleRate: 16_000,
+	windowShiftRatio: 0.5,
+	clusterThreshold: 0.9,
+	minDurationOn: 0.5,
+	minDurationOff: 0.5,
+}
+
+export type DiarizationProgress = { stage: 'segmenting' | 'embedding' | 'clustering'; done: number; total: number }
+
+type Labels = { data: Uint8Array; frames: number; cols: number } // row-major (frames x cols)
+
+function powersetMapping(cfg: DiarizationConfig): Uint8Array[] {
+	const rows: Uint8Array[] = []
+	for (let c = 0; c < cfg.numClasses; c++) rows.push(new Uint8Array(cfg.numSpeakers))
+	let k = 1
+	for (let i = 1; i <= cfg.powersetMaxClasses; i++) {
+		if (i === 1) {
+			for (let j = 0; j < cfg.numSpeakers; j++, k++) rows[k][j] = 1
+		} else if (i === 2) {
+			for (let j = 0; j < cfg.numSpeakers; j++) {
+				for (let m = j + 1; m < cfg.numSpeakers; m++, k++) {
+					rows[k][j] = 1
+					rows[k][m] = 1
+				}
+			}
+		} else {
+			throw new Error(`powerset_max_classes = ${i} is not supported`)
+		}
+	}
+	return rows
+}
+
+function windowShiftSamples(cfg: DiarizationConfig): number {
+	const shift = cfg.windowShiftRatio * cfg.windowSize
+	if (!Number.isFinite(shift) || shift < 1) return 1
+	if (shift > cfg.windowSize) return cfg.windowSize
+	return Math.floor(shift)
+}
+
+/** Window starts: every `shift` samples, plus a zero-padded tail window if needed. */
+function planWindows(n: number, cfg: DiarizationConfig): { starts: number[]; hasLastChunk: boolean } {
+	const W = cfg.windowSize
+	const S = windowShiftSamples(cfg)
+	if (n <= W) return { starts: [0], hasLastChunk: false }
+	const numChunks = Math.floor((n - W) / S) + 1
+	const hasLastChunk = (n - W) % S > 0
+	const starts: number[] = []
+	for (let i = 0; i < numChunks; i++) starts.push(i * S)
+	if (hasLastChunk) starts.push(numChunks * S)
+	return { starts, hasLastChunk }
+}
+
+function toMultiLabel(logits: Float32Array, frames: number, cfg: DiarizationConfig, mapping: Uint8Array[]): Labels {
+	const data = new Uint8Array(frames * cfg.numSpeakers)
+	for (let f = 0; f < frames; f++) {
+		let best = 0
+		let bestVal = -Infinity
+		for (let c = 0; c < cfg.numClasses; c++) {
+			const v = logits[f * cfg.numClasses + c]
+			if (v > bestVal) {
+				bestVal = v
+				best = c
+			}
+		}
+		data.set(mapping[best], f * cfg.numSpeakers)
+	}
+	return { data, frames, cols: cfg.numSpeakers }
+}
+
+function totalFrames(numChunks: number, cfg: DiarizationConfig): number {
+	const S = windowShiftSamples(cfg)
+	return Math.floor((cfg.windowSize + (numChunks - 1) * S) / cfg.receptiveFieldShift) + 1
+}
+
+function chunkFrameStart(i: number, cfg: DiarizationConfig): number {
+	return Math.floor((i * windowShiftSamples(cfg)) / cfg.receptiveFieldShift + 0.5)
+}
+
+function computeSpeakersPerFrame(labels: Labels[], cfg: DiarizationConfig): Int32Array {
+	const numFrames = totalFrames(labels.length, cfg)
+	const count = new Float32Array(numFrames)
+	const weight = new Float32Array(numFrames)
+	labels.forEach((label, i) => {
+		const start = chunkFrameStart(i, cfg)
+		for (let f = 0; f < label.frames; f++) {
+			let s = 0
+			for (let c = 0; c < label.cols; c++) s += label.data[f * label.cols + c]
+			count[start + f] += s
+			weight[start + f] += 1
+		}
+	})
+	const out = new Int32Array(numFrames)
+	for (let f = 0; f < numFrames; f++) out[f] = Math.floor(count[f] / (weight[f] + 1e-12) + 0.5)
+	return out
+}
+
+/** Frames where several speakers talk at once are excluded from embedding. */
+function excludeOverlap(label: Labels): Labels {
+	const data = new Uint8Array(label.data.length)
+	for (let f = 0; f < label.frames; f++) {
+		let s = 0
+		for (let c = 0; c < label.cols; c++) s += label.data[f * label.cols + c]
+		if (s < 2) data.set(label.data.subarray(f * label.cols, (f + 1) * label.cols), f * label.cols)
+	}
+	return { data, frames: label.frames, cols: label.cols }
+}
+
+type SampleRange = [number, number]
+
+function chunkSpeakerSampleIndexes(labels: Labels[], cfg: DiarizationConfig): { pairs: [number, number][]; ranges: SampleRange[][] } {
+	const W = cfg.windowSize
+	const S = windowShiftSamples(cfg)
+	const pairs: [number, number][] = []
+	const ranges: SampleRange[][] = []
+	labels.forEach((raw, chunkIndex) => {
+		const label = excludeOverlap(raw)
+		const T = label.frames
+		const sampleOffset = chunkIndex * S
+		for (let speaker = 0; speaker < cfg.numSpeakers; speaker++) {
+			let sum = 0
+			for (let f = 0; f < T; f++) sum += label.data[f * label.cols + speaker]
+			if (sum < 10) continue // skip segments shorter than 10 frames
+
+			const speakerRanges: SampleRange[] = []
+			let isActive = false
+			let startIndex = 0
+			for (let k = 0; k < T; k++) {
+				const active = label.data[k * label.cols + speaker] !== 0
+				if (active) {
+					if (!isActive) {
+						isActive = true
+						startIndex = k
+					}
+				} else if (isActive) {
+					isActive = false
+					speakerRanges.push([
+						Math.floor(Math.fround((startIndex / T) * W) + sampleOffset),
+						Math.floor(Math.fround((k / T) * W) + sampleOffset),
+					])
+				}
+			}
+			if (isActive) {
+				speakerRanges.push([
+					Math.floor(Math.fround((startIndex / T) * W) + sampleOffset),
+					Math.floor(Math.fround(((T - 1) / T) * W) + sampleOffset),
+				])
+			}
+			pairs.push([chunkIndex, speaker])
+			ranges.push(speakerRanges)
+		}
+	})
+	return { pairs, ranges }
+}
+
+async function computeEmbeddings(
+	audio: Float32Array,
+	ranges: SampleRange[][],
+	models: DiarizationModels,
+	onProgress?: (p: DiarizationProgress) => void,
+): Promise<{ embeddings: Float32Array; rows: number; dim: number; validIndexes: number[] }> {
+	const n = audio.length
+	const validIndexes: number[] = []
+	const vectors: Float32Array[] = []
+	let dim = 0
+
+	for (let k = 0; k < ranges.length; k++) {
+		// The segments of one (chunk, speaker) pair are concatenated into a
+		// single waveform, as sherpa's stream does, and featurised as one.
+		let total = 0
+		for (const [s, e] of ranges[k]) total += Math.max(0, Math.min(e, n) - s)
+		const wave = new Float32Array(total)
+		let pos = 0
+		for (const [s, e] of ranges[k]) {
+			const end = Math.min(e, n)
+			if (end > s) {
+				wave.set(audio.subarray(s, end), pos)
+				pos += end - s
+			}
+		}
+		const { frames, data } = computeFbank(wave)
+		if (frames > 0) {
+			subtractGlobalMean(data, frames)
+			const emb = await models.embed(data, frames)
+			let finite = true
+			for (let i = 0; i < emb.length; i++) {
+				if (!Number.isFinite(emb[i])) {
+					finite = false
+					break
+				}
+			}
+			if (finite) {
+				vectors.push(emb)
+				validIndexes.push(k)
+				dim = emb.length
+			}
+		}
+		onProgress?.({ stage: 'embedding', done: k + 1, total: ranges.length })
+	}
+
+	const embeddings = new Float32Array(vectors.length * dim)
+	vectors.forEach((v, i) => embeddings.set(v, i * dim))
+	return { embeddings, rows: vectors.length, dim, validIndexes }
+}
+
+function relabel(labels: Labels[], numClusters: number, mapping: Map<string, number>): Labels[] {
+	return labels.map((label, chunkIndex) => {
+		const data = new Uint8Array(label.frames * numClusters)
+		for (let speaker = 0; speaker < label.cols; speaker++) {
+			const cluster = mapping.get(`${chunkIndex}:${speaker}`)
+			if (cluster === undefined || cluster < 0 || cluster >= numClusters) continue
+			for (let k = 0; k < label.frames; k++) {
+				if (label.data[k * label.cols + speaker] === 1) data[k * numClusters + cluster] = 1
+			}
+		}
+		return { data, frames: label.frames, cols: numClusters }
+	})
+}
+
+function computeSpeakerCount(labels: Labels[], numSamples: number, cfg: DiarizationConfig): Labels {
+	const cols = labels[0].cols
+	let numFrames = totalFrames(labels.length, cfg)
+	const count = new Uint8Array(numFrames * cols)
+	labels.forEach((label, i) => {
+		const start = chunkFrameStart(i, cfg)
+		for (let f = 0; f < label.frames; f++) {
+			for (let c = 0; c < cols; c++) count[(start + f) * cols + c] += label.data[f * cols + c]
+		}
+	})
+	const S = windowShiftSamples(cfg)
+	const hasLastChunk = (numSamples - cfg.windowSize) % S > 0
+	if (hasLastChunk) {
+		let lastFrame = Math.floor(numSamples / cfg.receptiveFieldShift)
+		if (lastFrame >= numFrames) lastFrame = numFrames - 1
+		numFrames = lastFrame + 1
+	}
+	return { data: count.subarray(0, numFrames * cols), frames: numFrames, cols }
+}
+
+function finalizeLabels(count: Labels, speakersPerFrame: Int32Array): Labels {
+	const { frames, cols } = count
+	const data = new Uint8Array(frames * cols)
+	const order = new Int32Array(cols)
+	for (let f = 0; f < frames; f++) {
+		const k = Math.max(0, Math.min(cols, speakersPerFrame[f]))
+		if (k === 0) continue
+		for (let c = 0; c < cols; c++) order[c] = c
+		// Top-k by count, descending; ties keep the lower index, like partial_sort's stable-ish output.
+		const row = count.data.subarray(f * cols, (f + 1) * cols)
+		const sorted = Array.from(order).sort((a, b) => row[b] - row[a] || a - b)
+		for (let m = 0; m < k; m++) data[f * cols + sorted[m]] = 1
+	}
+	return { data, frames, cols }
+}
+
+function mergeSegments(segments: SpeakerTurn[], gap: number): SpeakerTurn[] {
+	const out = segments.slice()
+	let changed = true
+	while (changed) {
+		changed = false
+		for (let i = 0; i < out.length - 1; i++) {
+			const a = out[i]
+			const b = out[i + 1]
+			let merged: SpeakerTurn | null = null
+			if (a.end < b.start && a.end + gap >= b.start) merged = { start: a.start, end: b.end, speaker: a.speaker }
+			else if (b.end < a.start && b.end + gap >= a.start) merged = { start: b.start, end: a.end, speaker: a.speaker }
+			if (merged) {
+				out[i] = merged
+				out.splice(i + 1, 1)
+				changed = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+function computeResult(finalLabels: Labels, cfg: DiarizationConfig): SpeakerTurn[] {
+	const { frames, cols } = finalLabels
+	const scale = cfg.receptiveFieldShift / cfg.sampleRate
+	const scaleOffset = (0.5 * cfg.receptiveFieldSize) / cfg.sampleRate
+	const result: SpeakerTurn[] = []
+
+	for (let speaker = 0; speaker < cols; speaker++) {
+		const at = (f: number) => finalLabels.data[f * cols + speaker]
+		const own: SpeakerTurn[] = []
+		let isActive = at(0) > 0
+		let startIndex = isActive ? 0 : -1
+		for (let f = 1; f < frames; f++) {
+			if (isActive) {
+				if (at(f) === 0) {
+					own.push({ start: startIndex * scale + scaleOffset, end: f * scale + scaleOffset, speaker })
+					isActive = false
+				}
+			} else if (at(f) === 1) {
+				isActive = true
+				startIndex = f
+			}
+		}
+		if (isActive) own.push({ start: startIndex * scale + scaleOffset, end: (frames - 1) * scale + scaleOffset, speaker })
+
+		for (const seg of mergeSegments(own, cfg.minDurationOff)) {
+			if (seg.end - seg.start > cfg.minDurationOn) result.push(seg)
+		}
+	}
+	return result.sort((a, b) => a.start - b.start || a.speaker - b.speaker)
+}
+
+/**
+ * Diarize a 16 kHz mono recording. Returns raw speaker turns with sherpa's
+ * arbitrary speaker ids; callers prune and renumber (see label.ts).
+ */
+export async function diarize(
+	audio: Float32Array,
+	models: DiarizationModels,
+	cfg: DiarizationConfig = DEFAULT_DIARIZATION_CONFIG,
+	onProgress?: (p: DiarizationProgress) => void,
+): Promise<SpeakerTurn[]> {
+	const n = audio.length
+	if (n <= 0) return []
+	const mapping = powersetMapping(cfg)
+
+	// 1. Segmentation over sliding windows.
+	const { starts, hasLastChunk } = planWindows(n, cfg)
+	const labels: Labels[] = []
+	for (let i = 0; i < starts.length; i++) {
+		const start = starts[i]
+		let window: Float32Array
+		if (start + cfg.windowSize <= n) {
+			window = audio.subarray(start, start + cfg.windowSize)
+		} else {
+			window = new Float32Array(cfg.windowSize)
+			window.set(audio.subarray(start, n))
+		}
+		const { data, frames } = await models.segment(window)
+		labels.push(toMultiLabel(data, frames, cfg, mapping))
+		onProgress?.({ stage: 'segmenting', done: i + 1, total: starts.length })
+	}
+
+	// One window: local speakers are the final speakers.
+	if (labels.length === 1) {
+		let label = labels[0]
+		if (n > cfg.windowSize && hasLastChunk) {
+			const keep = Math.min(Math.floor(n / cfg.receptiveFieldShift), label.frames)
+			label = { data: label.data.subarray(0, keep * label.cols), frames: keep, cols: label.cols }
+		}
+		return computeResult(label, cfg)
+	}
+
+	// 2. How many speakers are active at each frame (vote across overlapping windows).
+	const speakersPerFrame = computeSpeakersPerFrame(labels, cfg)
+	let anySpeech = false
+	for (let f = 0; f < speakersPerFrame.length; f++) {
+		if (speakersPerFrame[f] > 0) {
+			anySpeech = true
+			break
+		}
+	}
+	if (!anySpeech) return []
+
+	// 3. Embed every (window, local speaker) pair.
+	const { pairs, ranges } = chunkSpeakerSampleIndexes(labels, cfg)
+	const { embeddings, rows, dim, validIndexes } = await computeEmbeddings(audio, ranges, models, onProgress)
+	if (rows === 0) return []
+
+	// 4. Cluster and map (window, local speaker) → global speaker.
+	onProgress?.({ stage: 'clustering', done: 0, total: 1 })
+	const clusters = clusterEmbeddings(embeddings, rows, dim, cfg.clusterThreshold)
+	let numClusters = 0
+	for (let i = 0; i < clusters.length; i++) numClusters = Math.max(numClusters, clusters[i] + 1)
+	const chunkSpeakerToCluster = new Map<string, number>()
+	validIndexes.forEach((pairIndex, k) => {
+		const [chunk, speaker] = pairs[pairIndex]
+		chunkSpeakerToCluster.set(`${chunk}:${speaker}`, clusters[k])
+	})
+
+	// 5. Vote per frame with the global ids and turn frames into segments.
+	const relabelled = relabel(labels, numClusters, chunkSpeakerToCluster)
+	const count = computeSpeakerCount(relabelled, n, cfg)
+	const finalLabels = finalizeLabels(count, speakersPerFrame)
+	onProgress?.({ stage: 'clustering', done: 1, total: 1 })
+	return computeResult(finalLabels, cfg)
+}

--- a/frontend/src/ondevice/hub.ts
+++ b/frontend/src/ondevice/hub.ts
@@ -55,6 +55,42 @@ async function probe(url: string): Promise<boolean | null> {
 	return null
 }
 
+/** Content-Length of `url`, or null if the host will not say. */
+async function contentLength(url: string): Promise<number | null> {
+	try {
+		const res = await fetch(url, { method: 'HEAD' })
+		const length = Number(res.headers.get('content-length'))
+		return res.ok && length > 0 ? length : null
+	} catch {
+		return null
+	}
+}
+
+const measured = new Map<string, Promise<number | null>>()
+
+/**
+ * How many bytes a plan downloads, asked of whichever host is configured.
+ * Not a constant: VITE_PARAKEET_MODEL_BASE can point at a custom build whose
+ * files are nothing like the upstream sizes — a self-quantized encoder serves
+ * the same weights under both plan filenames. Null when the host hides
+ * Content-Length, and cached per plan+base, since the panel shows a chip per
+ * plan and nothing here changes while the page lives.
+ */
+export async function measurePlanBytes(plan: ParakeetPlan, customBase?: string): Promise<number | null> {
+	const key = `${plan}@${customBase ?? HF_REPO}`
+	const pending =
+		measured.get(key) ??
+		(async () => {
+			const files = await resolveModelFiles(plan, customBase)
+			const urls = [files.encoder, files.decoder, files.tokenizer, ...(files.encoderData ? [files.encoderData] : [])]
+			const sizes = await Promise.all(urls.map(contentLength))
+			// One unknown file makes the total a lie, so report nothing.
+			return sizes.some((size) => size === null) ? null : sizes.reduce((total, size) => total! + size!, 0)
+		})().catch(() => null)
+	measured.set(key, pending)
+	return pending
+}
+
 /** Find a base URL that has the files this plan needs. */
 export async function resolveModelFiles(plan: ParakeetPlan, customBase?: string): Promise<ResolvedFiles> {
 	const encoderName = plan === 'gpu-fp16' ? 'encoder-model.fp16.onnx' : 'encoder-model.int8.onnx'

--- a/frontend/src/ondevice/hub.ts
+++ b/frontend/src/ondevice/hub.ts
@@ -1,0 +1,157 @@
+/**
+ * Model file resolution and download for the Parakeet worker.
+ *
+ * parakeet.js's own hub helper assembles each file in memory and then writes
+ * the whole blob to IndexedDB before ONNX Runtime gets to see it — for a
+ * 1.2 GB encoder that is several GB of transient memory and a long, silent
+ * pause. Here each file streams straight into the Cache API (disk-backed),
+ * and ORT is handed a blob URL backed by that cache entry.
+ *
+ * Files can be self-hosted: point VITE_PARAKEET_MODEL_BASE at a directory
+ * holding the same file names as the Hugging Face repo.
+ */
+import type { ParakeetPlan } from './capabilities'
+
+export const HF_REPO = 'ysdede/parakeet-tdt-0.6b-v3-onnx'
+const CACHE_NAME = 'meetscribe-parakeet-v1'
+/** Branches to try, in order; the parakeet.js demo pins the second for fp16. */
+const REVISIONS = ['main', 'feat/fp16-canonical-v3']
+
+export interface ResolvedFiles {
+	base: string
+	encoder: string
+	encoderData: string | null
+	decoder: string
+	tokenizer: string
+	filenames: { encoder: string; decoder: string }
+}
+
+export type ProgressFn = (file: string, loaded: number, total: number) => void
+
+const hfBase = (revision: string) => `https://huggingface.co/${HF_REPO}/resolve/${revision}/`
+
+/**
+ * Does `url` exist? true / false, or null when the server could not be asked
+ * (a CORS-blocked HEAD, an offline CDN) — the caller then tries optimistically.
+ */
+async function probe(url: string): Promise<boolean | null> {
+	try {
+		const res = await fetch(url, { method: 'HEAD' })
+		if (res.ok) return true
+		if (res.status === 404 || res.status === 403) return false
+	} catch {
+		/* fall through to a tiny ranged GET */
+	}
+	try {
+		const res = await fetch(url, { headers: { Range: 'bytes=0-0' } })
+		if (res.ok || res.status === 206) {
+			res.body?.cancel().catch(() => {})
+			return true
+		}
+		if (res.status === 404 || res.status === 403) return false
+	} catch {
+		/* unreachable */
+	}
+	return null
+}
+
+/** Find a base URL that has the files this plan needs. */
+export async function resolveModelFiles(plan: ParakeetPlan, customBase?: string): Promise<ResolvedFiles> {
+	const encoderName = plan === 'gpu-fp16' ? 'encoder-model.fp16.onnx' : 'encoder-model.int8.onnx'
+	const decoderName = 'decoder_joint-model.int8.onnx'
+	const bases = customBase ? [customBase.endsWith('/') ? customBase : `${customBase}/`] : REVISIONS.map(hfBase)
+
+	const build = async (base: string): Promise<ResolvedFiles> => ({
+		base,
+		encoder: base + encoderName,
+		encoderData: (await probe(`${base + encoderName}.data`)) === true ? `${base + encoderName}.data` : null,
+		decoder: base + decoderName,
+		tokenizer: base + 'vocab.txt',
+		filenames: { encoder: encoderName, decoder: decoderName },
+	})
+
+	let unprobed: string | null = null
+	for (const base of bases) {
+		const found = await probe(base + encoderName)
+		if (found === true) return build(base)
+		if (found === null && unprobed === null) unprobed = base
+	}
+	if (unprobed) {
+		console.warn(`[hub] Could not check ${unprobed}${encoderName}; trying it anyway.`)
+		return build(unprobed)
+	}
+	throw new Error(`${encoderName} not found in ${customBase ?? HF_REPO} (checked ${bases.length} location${bases.length === 1 ? '' : 's'})`)
+}
+
+async function openCache(): Promise<Cache | null> {
+	try {
+		return typeof caches !== 'undefined' ? await caches.open(CACHE_NAME) : null
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Fetch `url` (streaming, with progress) into the Cache API and return a blob
+ * URL for it. A cached copy is used without touching the network. If the
+ * cache is unavailable or refuses the file (quota, private mode), the file is
+ * fetched again into memory instead.
+ */
+export async function downloadToObjectUrl(url: string, onProgress: ProgressFn, useCache = true): Promise<{ objectUrl: string; bytes: number; cached: boolean }> {
+	const file = url.split('/').pop() ?? url
+	const cache = useCache ? await openCache() : null
+
+	if (cache) {
+		const hit = await cache.match(url)
+		if (hit) {
+			const blob = await hit.blob()
+			onProgress(file, blob.size, blob.size)
+			return { objectUrl: URL.createObjectURL(blob), bytes: blob.size, cached: true }
+		}
+	}
+
+	const res = await fetch(url)
+	if (!res.ok || !res.body) throw new Error(`${file}: HTTP ${res.status}`)
+	const total = Number(res.headers.get('content-length') || 0)
+	const reader = res.body.getReader()
+	let loaded = 0
+
+	if (cache) {
+		try {
+			const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>()
+			const putPromise = cache.put(url, new Response(readable, { headers: { 'Content-Type': 'application/octet-stream', ...(total ? { 'Content-Length': String(total) } : {}) } }))
+			const writer = writable.getWriter()
+			const pump = (async () => {
+				for (;;) {
+					const { done, value } = await reader.read()
+					if (done) break
+					loaded += value.length
+					await writer.write(value)
+					onProgress(file, loaded, total || loaded)
+				}
+				await writer.close()
+			})()
+			await Promise.all([pump, putPromise])
+			const stored = await cache.match(url)
+			if (!stored) throw new Error('cache entry vanished')
+			const blob = await stored.blob()
+			return { objectUrl: URL.createObjectURL(blob), bytes: blob.size, cached: false }
+		} catch (err) {
+			console.warn(`[hub] Cache API could not store ${file}; downloading into memory instead.`, err)
+			reader.cancel().catch(() => {})
+			await cache.delete(url).catch(() => {})
+			return downloadToObjectUrl(url, onProgress, false)
+		}
+	}
+
+	const chunks: BlobPart[] = []
+	for (;;) {
+		const { done, value } = await reader.read()
+		if (done) break
+		loaded += value.length
+		chunks.push(value.slice().buffer as ArrayBuffer)
+		onProgress(file, loaded, total || loaded)
+	}
+	const blob = new Blob(chunks, { type: 'application/octet-stream' })
+	return { objectUrl: URL.createObjectURL(blob), bytes: blob.size, cached: false }
+}

--- a/frontend/src/ondevice/ort-webgpu.d.ts
+++ b/frontend/src/ondevice/ort-webgpu.d.ts
@@ -1,0 +1,8 @@
+/**
+ * `onnxruntime-web/webgpu` is an exports-map subpath, which this project's
+ * "moduleResolution": "node" cannot follow. Same types as the package root —
+ * only the bundled execution providers differ (see ortSetup.ts).
+ */
+declare module 'onnxruntime-web/webgpu' {
+	export * from 'onnxruntime-web'
+}

--- a/frontend/src/ondevice/ortSetup.ts
+++ b/frontend/src/ondevice/ortSetup.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared ONNX Runtime Web configuration for the on-device workers.
+ *
+ * The WASM binaries are served by Vite from the installed package rather
+ * than a CDN, so the app keeps working offline and behind strict CSPs.
+ * Multi-threading needs SharedArrayBuffer, which only exists on
+ * cross-origin-isolated pages — see the COOP/COEP headers in vite.config.ts
+ * and nginx.conf. Without it ORT silently runs single-threaded.
+ */
+import * as ort from 'onnxruntime-web'
+import wasmUrl from 'onnxruntime-web/ort-wasm-simd-threaded.jsep.wasm?url'
+
+let configured = false
+
+export function configureOrt(): { threads: number } {
+	if (!configured) {
+		// The bundled entry point carries its own JS glue; only the binary is external.
+		ort.env.wasm.wasmPaths = { wasm: wasmUrl }
+		const isolated = typeof SharedArrayBuffer !== 'undefined' && (self as unknown as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
+		// Leave a core for the UI thread and the audio pipeline.
+		ort.env.wasm.numThreads = isolated ? Math.max(1, Math.min(8, (navigator.hardwareConcurrency || 4) - 1)) : 1
+		ort.env.wasm.proxy = false
+		configured = true
+	}
+	return { threads: ort.env.wasm.numThreads ?? 1 }
+}
+
+export { ort }

--- a/frontend/src/ondevice/ortSetup.ts
+++ b/frontend/src/ondevice/ortSetup.ts
@@ -9,7 +9,6 @@
  */
 import * as ort from 'onnxruntime-web'
 import wasmUrl from 'onnxruntime-web/ort-wasm-simd-threaded.jsep.wasm?url'
-import mjsUrl from 'onnxruntime-web/ort-wasm-simd-threaded.jsep.mjs?url'
 
 /**
  * True inside one of ONNX Runtime's own helper workers. ORT spawns its
@@ -27,10 +26,12 @@ let configured = false
 
 export function configureOrt(): { threads: number } {
 	if (!configured) {
-		// Point ORT at the standalone glue + binary. With only the binary set, the
-		// bundled entry uses its inlined glue, whose import.meta.url is *our* worker
-		// chunk — so every pthread would re-run this whole file (see isOrtHelperWorker).
-		ort.env.wasm.wasmPaths = { mjs: mjsUrl, wasm: wasmUrl }
+		// Only the binary is external. ORT's bundled entry keeps its JS glue
+		// inlined, so no extra `.mjs` asset is emitted — a file many static
+		// hosts serve with a non-JS MIME type, which a module import rejects.
+		// The cost is that ORT spawns its pthreads from *our* worker chunk;
+		// isOrtHelperWorker() below is what makes that safe.
+		ort.env.wasm.wasmPaths = { wasm: wasmUrl }
 		const isolated = typeof SharedArrayBuffer !== 'undefined' && (self as unknown as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
 		// Leave a core for the UI thread and the audio pipeline.
 		ort.env.wasm.numThreads = isolated ? Math.max(1, Math.min(8, (navigator.hardwareConcurrency || 4) - 1)) : 1

--- a/frontend/src/ondevice/ortSetup.ts
+++ b/frontend/src/ondevice/ortSetup.ts
@@ -1,14 +1,25 @@
 /**
  * Shared ONNX Runtime Web configuration for the on-device workers.
  *
+ * Note the entry point: `onnxruntime-web/webgpu`, not `onnxruntime-web`. The
+ * default entry ships ORT's older JSEP WebGPU implementation, whose
+ * MatMulNBits kernel accepts 4-bit weights only — an 8-bit weight-only
+ * encoder (scripts/quantize_parakeet_encoder.py) fails session creation with
+ * "nbits_ == 4 was false". This entry carries the newer native WebGPU EP,
+ * which handles 2, 4 and 8 bits, and still registers the wasm backend for the
+ * CPU plan and for diarization. It is the asyncify build, so it works without
+ * JSPI (Firefox and Safari have none); parakeet.js imports plain
+ * `onnxruntime-web` internally, which vite.config.ts aliases here so both
+ * share one runtime.
+ *
  * The WASM binaries are served by Vite from the installed package rather
  * than a CDN, so the app keeps working offline and behind strict CSPs.
  * Multi-threading needs SharedArrayBuffer, which only exists on
  * cross-origin-isolated pages — see the COOP/COEP headers in vite.config.ts
  * and nginx.conf. Without it ORT silently runs single-threaded.
  */
-import * as ort from 'onnxruntime-web'
-import wasmUrl from 'onnxruntime-web/ort-wasm-simd-threaded.jsep.wasm?url'
+import * as ort from 'onnxruntime-web/webgpu'
+import wasmUrl from 'onnxruntime-web/ort-wasm-simd-threaded.asyncify.wasm?url'
 
 /**
  * True inside one of ONNX Runtime's own helper workers. ORT spawns its

--- a/frontend/src/ondevice/ortSetup.ts
+++ b/frontend/src/ondevice/ortSetup.ts
@@ -9,13 +9,28 @@
  */
 import * as ort from 'onnxruntime-web'
 import wasmUrl from 'onnxruntime-web/ort-wasm-simd-threaded.jsep.wasm?url'
+import mjsUrl from 'onnxruntime-web/ort-wasm-simd-threaded.jsep.mjs?url'
+
+/**
+ * True inside one of ONNX Runtime's own helper workers. ORT spawns its
+ * pthreads from `import.meta.url` of its glue code; when that glue is bundled
+ * into one of our workers, each pthread evaluates our worker file too. Our
+ * top-level code (message handlers above all) must then stay out of the way,
+ * or it overwrites the handler the pthread needs and ORT waits forever.
+ */
+export const isOrtHelperWorker = (): boolean => {
+	const name = (self as unknown as { name?: string }).name
+	return name === 'em-pthread' || name === 'ort-wasm-proxy-worker'
+}
 
 let configured = false
 
 export function configureOrt(): { threads: number } {
 	if (!configured) {
-		// The bundled entry point carries its own JS glue; only the binary is external.
-		ort.env.wasm.wasmPaths = { wasm: wasmUrl }
+		// Point ORT at the standalone glue + binary. With only the binary set, the
+		// bundled entry uses its inlined glue, whose import.meta.url is *our* worker
+		// chunk — so every pthread would re-run this whole file (see isOrtHelperWorker).
+		ort.env.wasm.wasmPaths = { mjs: mjsUrl, wasm: wasmUrl }
 		const isolated = typeof SharedArrayBuffer !== 'undefined' && (self as unknown as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
 		// Leave a core for the UI thread and the audio pipeline.
 		ort.env.wasm.numThreads = isolated ? Math.max(1, Math.min(8, (navigator.hardwareConcurrency || 4) - 1)) : 1

--- a/frontend/src/ondevice/parakeet.worker.ts
+++ b/frontend/src/ondevice/parakeet.worker.ts
@@ -9,7 +9,7 @@
  * parakeet.js / ORT is forwarded to the page so a stall is diagnosable.
  */
 import { fromUrls, type ParakeetModel } from 'parakeet.js'
-import { configureOrt } from './ortSetup'
+import { configureOrt, isOrtHelperWorker } from './ortSetup'
 import { downloadToObjectUrl, resolveModelFiles } from './hub'
 import type { ParakeetPlan } from './capabilities'
 import type { TranscribeWord } from './types'
@@ -21,6 +21,7 @@ export type ParakeetWorkerRequest =
 export type ParakeetWorkerResponse =
 	| { type: 'download'; files: Record<string, { loaded: number; total: number }>; cached: boolean }
 	| { type: 'status'; text: string }
+	| { type: 'downloaded'; bytes: number; cached: boolean }
 	| { type: 'log'; level: 'log' | 'warn' | 'error'; text: string }
 	| { type: 'loaded'; plan: ParakeetPlan; backend: 'webgpu' | 'wasm'; encoderQuant: string; decoderQuant: string; loadMs: number; downloadBytes: number; cached: boolean; threads: number; source: string }
 	| { type: 'transcribed'; id: number; text: string; words: TranscribeWord[]; audioSeconds: number; ms: number }
@@ -28,19 +29,21 @@ export type ParakeetWorkerResponse =
 
 const post = (msg: ParakeetWorkerResponse) => self.postMessage(msg)
 
-// Mirror the worker's console to the page (parakeet.js and ORT log there).
-for (const level of ['log', 'warn', 'error'] as const) {
-	const original = console[level].bind(console)
-	console[level] = (...args: unknown[]) => {
-		original(...args)
-		try {
-			post({ type: 'log', level, text: args.map((a) => (typeof a === 'string' ? a : a instanceof Error ? a.message : JSON.stringify(a))).join(' ').slice(0, 400) })
-		} catch {
-			/* not serialisable */
+function installDiagnostics() {
+	// Mirror the worker's console to the page (parakeet.js and ORT log there).
+	for (const level of ['log', 'warn', 'error'] as const) {
+		const original = console[level].bind(console)
+		console[level] = (...args: unknown[]) => {
+			original(...args)
+			try {
+				post({ type: 'log', level, text: args.map((a) => (typeof a === 'string' ? a : a instanceof Error ? a.message : JSON.stringify(a))).join(' ').slice(0, 400) })
+			} catch {
+				/* not serialisable */
+			}
 		}
 	}
+	self.addEventListener('unhandledrejection', (e) => post({ type: 'error', stage: 'session', message: `Unhandled: ${e.reason instanceof Error ? e.reason.message : String(e.reason)}` }))
 }
-self.addEventListener('unhandledrejection', (e) => post({ type: 'error', stage: 'session', message: `Unhandled: ${e.reason instanceof Error ? e.reason.message : String(e.reason)}` }))
 
 let model: ParakeetModel | null = null
 
@@ -80,6 +83,7 @@ async function load(plan: ParakeetPlan, modelBase?: string) {
 		return
 	}
 
+	post({ type: 'downloaded', bytes: downloadBytes, cached: allCached })
 	const backend = plan === 'gpu-fp16' ? 'webgpu' : 'wasm'
 	post({ type: 'status', text: `Loading ${(downloadBytes / 1e9).toFixed(2)} GB into ${backend === 'webgpu' ? 'GPU + ' : ''}memory…` })
 	try {
@@ -130,12 +134,17 @@ async function transcribe(id: number, audio: Float32Array, sampleRate: number) {
 	})
 }
 
-self.onmessage = async (event: MessageEvent<ParakeetWorkerRequest>) => {
-	const msg = event.data
-	try {
-		if (msg.type === 'load') await load(msg.plan, msg.modelBase)
-		else if (msg.type === 'transcribe') await transcribe(msg.id, msg.audio, msg.sampleRate)
-	} catch (err) {
-		post({ type: 'error', id: msg.type === 'transcribe' ? msg.id : undefined, stage: msg.type === 'transcribe' ? 'transcribe' : 'session', message: err instanceof Error ? err.message : String(err) })
+// Only the real worker installs handlers; an ORT pthread evaluating this
+// file must leave `self.onmessage` to ORT.
+if (!isOrtHelperWorker()) {
+	installDiagnostics()
+	self.onmessage = async (event: MessageEvent<ParakeetWorkerRequest>) => {
+		const msg = event.data
+		try {
+			if (msg.type === 'load') await load(msg.plan, msg.modelBase)
+			else if (msg.type === 'transcribe') await transcribe(msg.id, msg.audio, msg.sampleRate)
+		} catch (err) {
+			post({ type: 'error', id: msg.type === 'transcribe' ? msg.id : undefined, stage: msg.type === 'transcribe' ? 'transcribe' : 'session', message: err instanceof Error ? err.message : String(err) })
+		}
 	}
 }

--- a/frontend/src/ondevice/parakeet.worker.ts
+++ b/frontend/src/ondevice/parakeet.worker.ts
@@ -47,9 +47,23 @@ function installDiagnostics() {
 
 let model: ParakeetModel | null = null
 
+/**
+ * Before hub.ts existed, parakeet.js's own downloader kept the model files in
+ * its IndexedDB (up to ~2 GB across both plans). Nothing reads that database
+ * any more, so drop it here instead of asking people to clear site data.
+ */
+function dropLegacyParakeetCache() {
+	try {
+		indexedDB.deleteDatabase('parakeet-cache-db')
+	} catch {
+		/* no IndexedDB in this context */
+	}
+}
+
 async function load(plan: ParakeetPlan, modelBase?: string) {
 	const { threads } = configureOrt()
 	const t0 = performance.now()
+	dropLegacyParakeetCache()
 
 	post({ type: 'status', text: 'Locating model files…' })
 	let files

--- a/frontend/src/ondevice/parakeet.worker.ts
+++ b/frontend/src/ondevice/parakeet.worker.ts
@@ -3,55 +3,117 @@
  * Web Worker: speech recognition on this device with NVIDIA Parakeet TDT
  * 0.6B v3 through parakeet.js (ONNX Runtime Web).
  *
- * Model files come from the Hugging Face Hub and are cached by parakeet.js in
- * IndexedDB, so the ~0.6–1.2 GB download happens once per browser. Two plans:
- * the encoder on WebGPU in fp16, or everything on WASM with an int8 encoder.
+ * Two plans: the encoder on WebGPU in fp16 (decoder on WASM), or everything
+ * on WASM with an int8 encoder. Model files stream into the Cache API once
+ * (see hub.ts) and load from disk afterwards. Every console line from
+ * parakeet.js / ORT is forwarded to the page so a stall is diagnosable.
  */
-import { fromHub, type ParakeetModel } from 'parakeet.js'
-import type { TranscribeWord } from './types'
+import { fromUrls, type ParakeetModel } from 'parakeet.js'
 import { configureOrt } from './ortSetup'
+import { downloadToObjectUrl, resolveModelFiles } from './hub'
 import type { ParakeetPlan } from './capabilities'
+import type { TranscribeWord } from './types'
 
 export type ParakeetWorkerRequest =
-	| { type: 'load'; plan: ParakeetPlan }
+	| { type: 'load'; plan: ParakeetPlan; modelBase?: string }
 	| { type: 'transcribe'; id: number; audio: Float32Array; sampleRate: number }
 
 export type ParakeetWorkerResponse =
-	| { type: 'download'; file: string; loaded: number; total: number; files: Record<string, { loaded: number; total: number }> }
-	| { type: 'loaded'; plan: ParakeetPlan; backend: 'webgpu' | 'wasm'; encoderQuant: string; decoderQuant: string; loadMs: number; downloadBytes: number; threads: number }
+	| { type: 'download'; files: Record<string, { loaded: number; total: number }>; cached: boolean }
+	| { type: 'status'; text: string }
+	| { type: 'log'; level: 'log' | 'warn' | 'error'; text: string }
+	| { type: 'loaded'; plan: ParakeetPlan; backend: 'webgpu' | 'wasm'; encoderQuant: string; decoderQuant: string; loadMs: number; downloadBytes: number; cached: boolean; threads: number; source: string }
 	| { type: 'transcribed'; id: number; text: string; words: TranscribeWord[]; audioSeconds: number; ms: number }
-	| { type: 'error'; id?: number; message: string }
+	| { type: 'error'; id?: number; stage?: 'resolve' | 'download' | 'session' | 'transcribe'; message: string }
 
-const MODEL_KEY = 'parakeet-tdt-0.6b-v3'
 const post = (msg: ParakeetWorkerResponse) => self.postMessage(msg)
+
+// Mirror the worker's console to the page (parakeet.js and ORT log there).
+for (const level of ['log', 'warn', 'error'] as const) {
+	const original = console[level].bind(console)
+	console[level] = (...args: unknown[]) => {
+		original(...args)
+		try {
+			post({ type: 'log', level, text: args.map((a) => (typeof a === 'string' ? a : a instanceof Error ? a.message : JSON.stringify(a))).join(' ').slice(0, 400) })
+		} catch {
+			/* not serialisable */
+		}
+	}
+}
+self.addEventListener('unhandledrejection', (e) => post({ type: 'error', stage: 'session', message: `Unhandled: ${e.reason instanceof Error ? e.reason.message : String(e.reason)}` }))
 
 let model: ParakeetModel | null = null
 
-async function load(plan: ParakeetPlan) {
+async function load(plan: ParakeetPlan, modelBase?: string) {
 	const { threads } = configureOrt()
 	const t0 = performance.now()
-	const files: Record<string, { loaded: number; total: number }> = {}
+
+	post({ type: 'status', text: 'Locating model files…' })
+	let files
+	try {
+		files = await resolveModelFiles(plan, modelBase)
+	} catch (err) {
+		post({ type: 'error', stage: 'resolve', message: err instanceof Error ? err.message : String(err) })
+		return
+	}
+
+	const progress: Record<string, { loaded: number; total: number }> = {}
+	let allCached = true
+	const report = (file: string, loaded: number, total: number) => {
+		progress[file] = { loaded, total }
+		post({ type: 'download', files: { ...progress }, cached: allCached })
+	}
+	const urls: Record<string, string> = {}
 	let downloadBytes = 0
-	const progress = ({ file, loaded, total }: { file: string; loaded: number; total: number }) => {
-		files[file] = { loaded, total }
-		downloadBytes = Object.values(files).reduce((s, f) => s + f.loaded, 0)
-		post({ type: 'download', file, loaded, total, files: { ...files } })
+	try {
+		// Sequential on purpose: one big stream saturates the link, and the
+		// progress bar is easier to read.
+		for (const [key, url] of Object.entries({ encoder: files.encoder, encoderData: files.encoderData, decoder: files.decoder, tokenizer: files.tokenizer })) {
+			if (!url) continue
+			const { objectUrl, bytes, cached } = await downloadToObjectUrl(url, report)
+			urls[key] = objectUrl
+			downloadBytes += bytes
+			if (!cached) allCached = false
+		}
+	} catch (err) {
+		post({ type: 'error', stage: 'download', message: err instanceof Error ? err.message : String(err) })
+		return
 	}
 
 	const backend = plan === 'gpu-fp16' ? 'webgpu' : 'wasm'
-	const encoderQuant = plan === 'gpu-fp16' ? 'fp16' : 'int8'
-	// parakeet.js can only run the decoder on WASM, and int8 is its fastest
-	// form there.
-	const decoderQuant = 'int8'
-	model = await fromHub(MODEL_KEY, {
+	post({ type: 'status', text: `Loading ${(downloadBytes / 1e9).toFixed(2)} GB into ${backend === 'webgpu' ? 'GPU + ' : ''}memory…` })
+	try {
+		model = await fromUrls({
+			encoderUrl: urls.encoder,
+			encoderDataUrl: urls.encoderData ?? null,
+			decoderUrl: urls.decoder,
+			tokenizerUrl: files.tokenizer, // small text file, fetched directly
+			filenames: files.filenames,
+			// parakeet.js only knows 'webgpu-hybrid' | 'webgpu-strict' | 'wasm'
+			// when it builds the execution-provider list; plain 'webgpu' leaves it empty.
+			backend: backend === 'webgpu' ? 'webgpu-hybrid' : 'wasm',
+			preprocessorBackend: 'js',
+			cpuThreads: threads,
+		})
+	} catch (err) {
+		post({ type: 'error', stage: 'session', message: err instanceof Error ? err.message : String(err) })
+		return
+	} finally {
+		for (const u of Object.values(urls)) URL.revokeObjectURL(u)
+	}
+
+	post({
+		type: 'loaded',
+		plan,
 		backend,
-		encoderQuant,
-		decoderQuant,
-		preprocessorBackend: 'js',
-		cpuThreads: threads,
-		progress,
+		encoderQuant: plan === 'gpu-fp16' ? 'fp16' : 'int8',
+		decoderQuant: 'int8',
+		loadMs: performance.now() - t0,
+		downloadBytes,
+		cached: allCached,
+		threads,
+		source: files.base,
 	})
-	post({ type: 'loaded', plan, backend, encoderQuant, decoderQuant, loadMs: performance.now() - t0, downloadBytes, threads })
 }
 
 async function transcribe(id: number, audio: Float32Array, sampleRate: number) {
@@ -62,7 +124,7 @@ async function transcribe(id: number, audio: Float32Array, sampleRate: number) {
 		type: 'transcribed',
 		id,
 		text: result.utterance_text ?? '',
-		words: result.words ?? [],
+		words: (result.words ?? []) as TranscribeWord[],
 		audioSeconds: audio.length / sampleRate,
 		ms: performance.now() - t0,
 	})
@@ -71,9 +133,9 @@ async function transcribe(id: number, audio: Float32Array, sampleRate: number) {
 self.onmessage = async (event: MessageEvent<ParakeetWorkerRequest>) => {
 	const msg = event.data
 	try {
-		if (msg.type === 'load') await load(msg.plan)
+		if (msg.type === 'load') await load(msg.plan, msg.modelBase)
 		else if (msg.type === 'transcribe') await transcribe(msg.id, msg.audio, msg.sampleRate)
 	} catch (err) {
-		post({ type: 'error', id: msg.type === 'transcribe' ? msg.id : undefined, message: err instanceof Error ? err.message : String(err) })
+		post({ type: 'error', id: msg.type === 'transcribe' ? msg.id : undefined, stage: msg.type === 'transcribe' ? 'transcribe' : 'session', message: err instanceof Error ? err.message : String(err) })
 	}
 }

--- a/frontend/src/ondevice/parakeet.worker.ts
+++ b/frontend/src/ondevice/parakeet.worker.ts
@@ -1,0 +1,79 @@
+/// <reference lib="webworker" />
+/**
+ * Web Worker: speech recognition on this device with NVIDIA Parakeet TDT
+ * 0.6B v3 through parakeet.js (ONNX Runtime Web).
+ *
+ * Model files come from the Hugging Face Hub and are cached by parakeet.js in
+ * IndexedDB, so the ~0.6–1.2 GB download happens once per browser. Two plans:
+ * the encoder on WebGPU in fp16, or everything on WASM with an int8 encoder.
+ */
+import { fromHub, type ParakeetModel } from 'parakeet.js'
+import type { TranscribeWord } from './types'
+import { configureOrt } from './ortSetup'
+import type { ParakeetPlan } from './capabilities'
+
+export type ParakeetWorkerRequest =
+	| { type: 'load'; plan: ParakeetPlan }
+	| { type: 'transcribe'; id: number; audio: Float32Array; sampleRate: number }
+
+export type ParakeetWorkerResponse =
+	| { type: 'download'; file: string; loaded: number; total: number; files: Record<string, { loaded: number; total: number }> }
+	| { type: 'loaded'; plan: ParakeetPlan; backend: 'webgpu' | 'wasm'; encoderQuant: string; decoderQuant: string; loadMs: number; downloadBytes: number; threads: number }
+	| { type: 'transcribed'; id: number; text: string; words: TranscribeWord[]; audioSeconds: number; ms: number }
+	| { type: 'error'; id?: number; message: string }
+
+const MODEL_KEY = 'parakeet-tdt-0.6b-v3'
+const post = (msg: ParakeetWorkerResponse) => self.postMessage(msg)
+
+let model: ParakeetModel | null = null
+
+async function load(plan: ParakeetPlan) {
+	const { threads } = configureOrt()
+	const t0 = performance.now()
+	const files: Record<string, { loaded: number; total: number }> = {}
+	let downloadBytes = 0
+	const progress = ({ file, loaded, total }: { file: string; loaded: number; total: number }) => {
+		files[file] = { loaded, total }
+		downloadBytes = Object.values(files).reduce((s, f) => s + f.loaded, 0)
+		post({ type: 'download', file, loaded, total, files: { ...files } })
+	}
+
+	const backend = plan === 'gpu-fp16' ? 'webgpu' : 'wasm'
+	const encoderQuant = plan === 'gpu-fp16' ? 'fp16' : 'int8'
+	// parakeet.js can only run the decoder on WASM, and int8 is its fastest
+	// form there.
+	const decoderQuant = 'int8'
+	model = await fromHub(MODEL_KEY, {
+		backend,
+		encoderQuant,
+		decoderQuant,
+		preprocessorBackend: 'js',
+		cpuThreads: threads,
+		progress,
+	})
+	post({ type: 'loaded', plan, backend, encoderQuant, decoderQuant, loadMs: performance.now() - t0, downloadBytes, threads })
+}
+
+async function transcribe(id: number, audio: Float32Array, sampleRate: number) {
+	if (!model) throw new Error('Parakeet is not loaded')
+	const t0 = performance.now()
+	const result = await model.transcribe(audio, sampleRate, { returnTimestamps: true, enableProfiling: false })
+	post({
+		type: 'transcribed',
+		id,
+		text: result.utterance_text ?? '',
+		words: result.words ?? [],
+		audioSeconds: audio.length / sampleRate,
+		ms: performance.now() - t0,
+	})
+}
+
+self.onmessage = async (event: MessageEvent<ParakeetWorkerRequest>) => {
+	const msg = event.data
+	try {
+		if (msg.type === 'load') await load(msg.plan)
+		else if (msg.type === 'transcribe') await transcribe(msg.id, msg.audio, msg.sampleRate)
+	} catch (err) {
+		post({ type: 'error', id: msg.type === 'transcribe' ? msg.id : undefined, message: err instanceof Error ? err.message : String(err) })
+	}
+}

--- a/frontend/src/ondevice/parakeet.worker.ts
+++ b/frontend/src/ondevice/parakeet.worker.ts
@@ -29,6 +29,22 @@ export type ParakeetWorkerResponse =
 
 const post = (msg: ParakeetWorkerResponse) => self.postMessage(msg)
 
+/** ANSI colour codes ORT emits, which would otherwise show up as "[0;93m". */
+// eslint-disable-next-line no-control-regex -- matching the escape byte is the point
+const ANSI = /\u001b\[[0-9;]*m/g
+
+/**
+ * ORT writes *all* of its native log lines to console.error, including
+ * warnings such as the harmless "Unknown CPU vendor". Take the real severity
+ * from the line's own "[W:" / "[E:" marker so a warning is not shown as a
+ * failure.
+ */
+function severityOf(text: string, fallback: 'log' | 'warn' | 'error'): 'log' | 'warn' | 'error' {
+	const marker = /\[([VIWE]):onnxruntime/.exec(text)
+	if (!marker) return fallback
+	return marker[1] === 'E' ? 'error' : marker[1] === 'W' ? 'warn' : 'log'
+}
+
 function installDiagnostics() {
 	// Mirror the worker's console to the page (parakeet.js and ORT log there).
 	for (const level of ['log', 'warn', 'error'] as const) {
@@ -36,7 +52,12 @@ function installDiagnostics() {
 		console[level] = (...args: unknown[]) => {
 			original(...args)
 			try {
-				post({ type: 'log', level, text: args.map((a) => (typeof a === 'string' ? a : a instanceof Error ? a.message : JSON.stringify(a))).join(' ').slice(0, 400) })
+				const text = args
+					.map((a) => (typeof a === 'string' ? a : a instanceof Error ? a.message : JSON.stringify(a)))
+					.join(' ')
+					.replace(ANSI, '')
+					.slice(0, 400)
+				post({ type: 'log', level: severityOf(text, level), text })
 			} catch {
 				/* not serialisable */
 			}

--- a/frontend/src/ondevice/testing/parakeetMock.ts
+++ b/frontend/src/ondevice/testing/parakeetMock.ts
@@ -1,0 +1,37 @@
+/**
+ * Stand-in for `parakeet.js` used by the browser test harness when Vite runs
+ * with PARAKEET_MOCK=1 (see vite.config.ts). It never touches the network:
+ * "download" is a short simulated progress ramp and "transcription" emits a
+ * placeholder word every 400 ms of audio with real timestamps, which is
+ * enough to exercise decoding, the worker protocol, chunk uploads, on-device
+ * diarization and the hand-over to the server. Not part of the app bundle.
+ */
+import type { TranscribeWord } from '../types'
+
+interface HubOptions {
+	backend?: string
+	progress?: (p: { file: string; loaded: number; total: number }) => void
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export async function fromHub(_key: string, options: HubOptions = {}) {
+	const files = { 'encoder-model.mock.onnx': 40_000_000, 'decoder_joint-model.int8.onnx': 6_000_000, 'vocab.txt': 20_000 }
+	for (const [file, total] of Object.entries(files)) {
+		for (let loaded = 0; loaded <= total; loaded += total / 4) {
+			options.progress?.({ file, loaded: Math.min(loaded, total), total })
+			await sleep(40)
+		}
+	}
+	return {
+		async transcribe(audio: Float32Array, sampleRate = 16_000) {
+			const seconds = audio.length / sampleRate
+			await sleep(Math.max(20, seconds * 15)) // ~60× realtime
+			const words: TranscribeWord[] = []
+			for (let t = 0; t + 0.4 <= seconds; t += 0.4) {
+				words.push({ text: `w${Math.round(t * 10)}${t % 4 < 0.01 ? '.' : ''}`, start_time: t, end_time: t + 0.3 })
+			}
+			return { utterance_text: words.map((w) => w.text).join(' '), words, is_final: true, metrics: null }
+		},
+	}
+}

--- a/frontend/src/ondevice/testing/parakeetMock.ts
+++ b/frontend/src/ondevice/testing/parakeetMock.ts
@@ -1,28 +1,19 @@
 /**
  * Stand-in for `parakeet.js` used by the browser test harness when Vite runs
- * with PARAKEET_MOCK=1 (see vite.config.ts). It never touches the network:
- * "download" is a short simulated progress ramp and "transcription" emits a
- * placeholder word every 400 ms of audio with real timestamps, which is
- * enough to exercise decoding, the worker protocol, chunk uploads, on-device
- * diarization and the hand-over to the server. Not part of the app bundle.
+ * with PARAKEET_MOCK=1 (see vite.config.ts). The real downloader (hub.ts)
+ * still runs — point VITE_PARAKEET_MODEL_BASE at a directory with the
+ * expected file names — but "transcription" emits a placeholder word every
+ * 400 ms of audio with real timestamps. That is enough to exercise decoding,
+ * the worker protocol, chunk uploads, on-device diarization and the hand-over
+ * to the server without a real model. Not part of the app bundle.
  */
 import type { TranscribeWord } from '../types'
 
-interface HubOptions {
-	backend?: string
-	progress?: (p: { file: string; loaded: number; total: number }) => void
-}
-
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
-export async function fromHub(_key: string, options: HubOptions = {}) {
-	const files = { 'encoder-model.mock.onnx': 40_000_000, 'decoder_joint-model.int8.onnx': 6_000_000, 'vocab.txt': 20_000 }
-	for (const [file, total] of Object.entries(files)) {
-		for (let loaded = 0; loaded <= total; loaded += total / 4) {
-			options.progress?.({ file, loaded: Math.min(loaded, total), total })
-			await sleep(40)
-		}
-	}
+export async function fromUrls() {
+	console.warn('[Parakeet.js mock] Creating ONNX sessions (pretend)…')
+	await sleep(300)
 	return {
 		async transcribe(audio: Float32Array, sampleRate = 16_000) {
 			const seconds = audio.length / sampleRate

--- a/frontend/src/ondevice/types.ts
+++ b/frontend/src/ondevice/types.ts
@@ -1,0 +1,7 @@
+/** One recognised word with its position in the audio, as parakeet.js reports it. */
+export interface TranscribeWord {
+	text: string
+	start_time: number
+	end_time: number
+	confidence?: number
+}

--- a/frontend/src/ondevice/useOnDevice.ts
+++ b/frontend/src/ondevice/useOnDevice.ts
@@ -231,14 +231,21 @@ export function useOnDevice(): OnDeviceController {
 							const total = Object.values(msg.files).reduce((sum, f) => sum + f.total, 0)
 							const startedAt = s.download?.startedAt ?? Date.now()
 							const elapsed = (Date.now() - startedAt) / 1000
-							return { download: { loaded, total, startedAt, bytesPerSec: elapsed > 0.5 ? loaded / elapsed : 0, done: false, cached: msg.cached, doneAt: null } }
+							return { statusText: null, download: { loaded, total, startedAt, bytesPerSec: elapsed > 0.5 ? loaded / elapsed : 0, done: false, cached: msg.cached, doneAt: null } }
 						})
-					} else if (msg.type === 'status') {
+					} else if (msg.type === 'downloaded') {
 						patch((s) => ({
-							statusText: msg.text,
-							// The first status after the last byte marks the start of the load-into-memory step.
-							download: s.download && !s.download.done && s.download.loaded >= s.download.total && s.download.total > 0 ? { ...s.download, done: true, doneAt: Date.now() } : s.download,
+							download: {
+								...(s.download ?? { startedAt: Date.now(), bytesPerSec: 0 }),
+								loaded: msg.bytes,
+								total: msg.bytes,
+								cached: msg.cached,
+								done: true,
+								doneAt: Date.now(),
+							},
 						}))
+					} else if (msg.type === 'status') {
+						patch({ statusText: msg.text })
 					} else if (msg.type === 'log') {
 						patch((s) => ({ log: [...s.log.slice(-29), `${msg.level === 'error' ? '❌ ' : msg.level === 'warn' ? '⚠️ ' : ''}${msg.text}`] }))
 					} else if (msg.type === 'loaded') {

--- a/frontend/src/ondevice/useOnDevice.ts
+++ b/frontend/src/ondevice/useOnDevice.ts
@@ -1,0 +1,508 @@
+/**
+ * Orchestrates on-device processing for a live recording:
+ *
+ *   recorder chunk (webm) ──decode──▶ 16 kHz PCM ──▶ Parakeet worker ──▶ text + word times
+ *                                        │                                    │
+ *                                        ▼                                    ▼
+ *                                  kept for later                 PUT /chunks/{i}/transcript
+ *
+ *   stop ──▶ wait for queue ──▶ diarization worker over all PCM ──▶ label ──▶ POST /finalize
+ *
+ * The recorder and the audio upload are untouched; this hook only adds a
+ * second consumer of every chunk. Everything it measures ends up in
+ * `state` for the panel and in `client_stats` on the meeting.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { apiUrl } from '../utils/api'
+import { detectCapabilities, resolvePlan, type DeviceCapabilities, type ParakeetPlan, type PlanChoice } from './capabilities'
+import { fetchModelManifest, finalizeMeeting, putChunkTranscript, requestServerFallback, type ModelManifest } from './api'
+import { labelTranscript, pruneMinorSpeakers, renumberByFirstAppearance, type SpeakerTurn, type TranscriptChunk, type TranscriptSegment } from './diarization/label'
+import type { ParakeetWorkerRequest, ParakeetWorkerResponse } from './parakeet.worker'
+import type { DiarizationWorkerRequest, DiarizationWorkerResponse } from './diarization.worker'
+import type { TranscribeWord } from './types'
+
+const SAMPLE_RATE = 16_000
+const STORAGE_ENABLED = 'meetscribe_ondevice'
+const STORAGE_PLAN = 'meetscribe_ondevice_plan'
+
+export type OnDevicePhase = 'idle' | 'loading' | 'ready' | 'diarizing' | 'finalizing' | 'error' | 'fallback'
+
+export interface DownloadState {
+	loaded: number
+	total: number
+	startedAt: number
+	bytesPerSec: number
+	done: boolean
+}
+
+export interface OnDeviceState {
+	enabled: boolean
+	planChoice: PlanChoice
+	plan: ParakeetPlan | null
+	caps: DeviceCapabilities | null
+	phase: OnDevicePhase
+	error: string | null
+	download: DownloadState | null
+	modelLoadMs: number | null
+	backend: 'webgpu' | 'wasm' | null
+	threads: number | null
+	transcription: { done: number; queued: number; audioSeconds: number; processMs: number }
+	diarization: { stage: string | null; done: number; total: number; ms: number | null; speakers: number | null; modelBytes: number | null; modelLoadMs: number | null }
+}
+
+export interface OnDeviceController {
+	state: OnDeviceState
+	setEnabled: (enabled: boolean) => void
+	setPlanChoice: (choice: PlanChoice) => void
+	/** True when a meeting started now would be processed on this device. */
+	isUsable: boolean
+	beginMeeting: (meetingId: string) => void
+	addChunk: (blob: Blob, index: number) => void
+	/** Drain, diarize, hand over. Resolves once the server has the transcript. */
+	finish: () => Promise<void>
+	/** What the status box should say while the server still reports nothing. */
+	localStage: 'diarizing' | 'summarizing' | null
+}
+
+const initialState = (): OnDeviceState => ({
+	enabled: (() => {
+		try {
+			return localStorage.getItem(STORAGE_ENABLED) === 'true'
+		} catch {
+			return false
+		}
+	})(),
+	planChoice: (() => {
+		try {
+			const v = localStorage.getItem(STORAGE_PLAN)
+			return v === 'gpu-fp16' || v === 'cpu-int8' ? v : 'auto'
+		} catch {
+			return 'auto'
+		}
+	})(),
+	plan: null,
+	caps: null,
+	phase: 'idle',
+	error: null,
+	download: null,
+	modelLoadMs: null,
+	backend: null,
+	threads: null,
+	transcription: { done: 0, queued: 0, audioSeconds: 0, processMs: 0 },
+	diarization: { stage: null, done: 0, total: 0, ms: null, speakers: null, modelBytes: null, modelLoadMs: null },
+})
+
+/** Decode a recorder chunk (a complete webm/opus file) to mono 16 kHz PCM. */
+async function decodeToPcm(blob: Blob): Promise<Float32Array> {
+	const bytes = await blob.arrayBuffer()
+	const probe = new OfflineAudioContext(1, 1, SAMPLE_RATE)
+	let decoded = await probe.decodeAudioData(bytes)
+	if (decoded.sampleRate !== SAMPLE_RATE) {
+		// Some browsers decode at the file's rate; render through a 16 kHz context to resample.
+		const frames = Math.ceil(decoded.duration * SAMPLE_RATE)
+		const ctx = new OfflineAudioContext(1, Math.max(1, frames), SAMPLE_RATE)
+		const source = ctx.createBufferSource()
+		source.buffer = decoded
+		source.connect(ctx.destination)
+		source.start()
+		decoded = await ctx.startRendering()
+	}
+	if (decoded.numberOfChannels === 1) return decoded.getChannelData(0).slice()
+	const out = new Float32Array(decoded.length)
+	for (let c = 0; c < decoded.numberOfChannels; c++) {
+		const data = decoded.getChannelData(c)
+		for (let i = 0; i < out.length; i++) out[i] += data[i] / decoded.numberOfChannels
+	}
+	return out
+}
+
+/**
+ * Group Parakeet's words into short segments so diarization can attribute
+ * them: a new segment at a pause > 0.6 s, after sentence punctuation, or
+ * every 24 words. Same shape as the Whisper segments the server stores.
+ */
+function wordsToSegments(words: TranscribeWord[], text: string, audioSeconds: number): TranscriptSegment[] {
+	if (words.length === 0) return text.trim() ? [{ start: 0, end: audioSeconds, text: text.trim() }] : []
+	const segments: TranscriptSegment[] = []
+	let current: TranscribeWord[] = []
+	const flush = () => {
+		if (current.length === 0) return
+		segments.push({ start: current[0].start_time, end: current[current.length - 1].end_time, text: current.map((w) => w.text).join(' ').trim() })
+		current = []
+	}
+	for (const word of words) {
+		const prev = current[current.length - 1]
+		if (prev && (word.start_time - prev.end_time > 0.6 || /[.!?…]$/.test(prev.text) || current.length >= 24)) flush()
+		current.push(word)
+	}
+	flush()
+	return segments.filter((s) => s.text)
+}
+
+interface ChunkRecord {
+	pcm: Float32Array
+	text: string | null
+	segments: TranscriptSegment[]
+}
+
+export function useOnDevice(): OnDeviceController {
+	const [state, setState] = useState<OnDeviceState>(initialState)
+	const stateRef = useRef(state)
+	stateRef.current = state
+	const patch = useCallback((update: Partial<OnDeviceState> | ((s: OnDeviceState) => Partial<OnDeviceState>)) => {
+		setState((s) => ({ ...s, ...(typeof update === 'function' ? update(s) : update) }))
+	}, [])
+
+	const parakeetRef = useRef<Worker | null>(null)
+	const diarizerRef = useRef<Worker | null>(null)
+	const parakeetReady = useRef<Promise<void> | null>(null)
+	const diarizerReady = useRef<Promise<void> | null>(null)
+	const manifestRef = useRef<ModelManifest | null>(null)
+
+	// Per-meeting data.
+	const meetingIdRef = useRef<string | null>(null)
+	const chunksRef = useRef<Map<number, ChunkRecord>>(new Map())
+	const queueRef = useRef<number[]>([])
+	const inFlightRef = useRef<number | null>(null)
+	const decodingRef = useRef(0)
+	const drainWaitersRef = useRef<(() => void)[]>([])
+	const pendingResolvers = useRef<Map<number, { resolve: (r: Extract<ParakeetWorkerResponse, { type: 'transcribed' }>) => void; reject: (e: Error) => void }>>(new Map())
+
+	// ---- capabilities ------------------------------------------------------
+	useEffect(() => {
+		detectCapabilities().then((caps) => patch({ caps }))
+	}, [patch])
+
+	const plan = useMemo(() => (state.caps ? resolvePlan(state.planChoice, state.caps) : null), [state.caps, state.planChoice])
+
+	// ---- workers -----------------------------------------------------------
+	const terminateWorkers = useCallback(() => {
+		parakeetRef.current?.terminate()
+		diarizerRef.current?.terminate()
+		parakeetRef.current = null
+		diarizerRef.current = null
+		parakeetReady.current = null
+		diarizerReady.current = null
+	}, [])
+
+	const loadWorkers = useCallback(
+		(chosen: ParakeetPlan) => {
+			terminateWorkers()
+			patch({ phase: 'loading', error: null, plan: chosen, download: null, modelLoadMs: null, backend: null })
+
+			const parakeet = new Worker(new URL('./parakeet.worker.ts', import.meta.url), { type: 'module' })
+			parakeetRef.current = parakeet
+			parakeetReady.current = new Promise<void>((resolve, reject) => {
+				parakeet.onmessage = (event: MessageEvent<ParakeetWorkerResponse>) => {
+					const msg = event.data
+					if (msg.type === 'download') {
+						patch((s) => {
+							const loaded = Object.values(msg.files).reduce((sum, f) => sum + f.loaded, 0)
+							const total = Object.values(msg.files).reduce((sum, f) => sum + f.total, 0)
+							const startedAt = s.download?.startedAt ?? Date.now()
+							const elapsed = (Date.now() - startedAt) / 1000
+							return { download: { loaded, total, startedAt, bytesPerSec: elapsed > 0.5 ? loaded / elapsed : 0, done: false } }
+						})
+					} else if (msg.type === 'loaded') {
+						patch((s) => ({
+							phase: 'ready',
+							modelLoadMs: msg.loadMs,
+							backend: msg.backend,
+							threads: msg.threads,
+							download: s.download ? { ...s.download, done: true } : { loaded: 0, total: 0, startedAt: Date.now(), bytesPerSec: 0, done: true },
+						}))
+						resolve()
+					} else if (msg.type === 'transcribed') {
+						pendingResolvers.current.get(msg.id)?.resolve(msg)
+						pendingResolvers.current.delete(msg.id)
+					} else if (msg.type === 'error') {
+						if (msg.id !== undefined) {
+							pendingResolvers.current.get(msg.id)?.reject(new Error(msg.message))
+							pendingResolvers.current.delete(msg.id)
+						} else {
+							patch({ phase: 'error', error: `Parakeet failed to load: ${msg.message} — flip the switch off and on to retry.` })
+							reject(new Error(msg.message))
+						}
+					}
+				}
+				parakeet.onerror = (e) => {
+					patch({ phase: 'error', error: `Parakeet worker crashed: ${e.message}` })
+					reject(new Error(e.message))
+				}
+			})
+			parakeetReady.current.catch(() => {})
+			parakeet.postMessage({ type: 'load', plan: chosen } satisfies ParakeetWorkerRequest)
+
+			const diarizer = new Worker(new URL('./diarization.worker.ts', import.meta.url), { type: 'module' })
+			diarizerRef.current = diarizer
+			diarizerReady.current = (async () => {
+				const manifest = await fetchModelManifest()
+				manifestRef.current = manifest
+				await new Promise<void>((resolve, reject) => {
+					diarizer.onmessage = (event: MessageEvent<DiarizationWorkerResponse>) => {
+						const msg = event.data
+						if (msg.type === 'loaded') {
+							patch((s) => ({ diarization: { ...s.diarization, modelBytes: msg.downloadBytes, modelLoadMs: msg.loadMs } }))
+							resolve()
+						} else if (msg.type === 'error') reject(new Error(msg.message))
+					}
+					diarizer.onerror = (e) => reject(new Error(e.message))
+					diarizer.postMessage({ type: 'load', segmentationUrl: manifest.segmentation.url, embeddingUrl: manifest.embedding.url } satisfies DiarizationWorkerRequest)
+				})
+			})()
+			// Diarization is optional: if its models are missing the meeting
+			// still gets a plain transcript, like the server without models.
+			diarizerReady.current.catch((err) => console.warn('On-device diarization unavailable:', err))
+		},
+		[patch, terminateWorkers],
+	)
+
+	// Load as soon as the feature is on and we know the plan, so the download
+	// happens before the meeting rather than during it.
+	useEffect(() => {
+		if (!state.enabled) {
+			if (state.phase !== 'idle' || state.plan !== null) {
+				terminateWorkers()
+				patch({ phase: 'idle', error: null, download: null, plan: null })
+			}
+			return
+		}
+		if (!plan) return
+		if (meetingIdRef.current) return // never swap models mid-meeting
+		// Load once per plan. A failed load stays failed until the user flips
+		// the switch (or picks another plan) — no silent retry loop.
+		if (state.plan !== plan || state.phase === 'idle') loadWorkers(plan)
+	}, [state.enabled, plan, state.plan, state.phase, loadWorkers, terminateWorkers, patch])
+
+	useEffect(() => () => terminateWorkers(), [terminateWorkers])
+
+	const setEnabled = useCallback(
+		(enabled: boolean) => {
+			try {
+				localStorage.setItem(STORAGE_ENABLED, String(enabled))
+			} catch {
+				/* private mode */
+			}
+			patch({ enabled })
+		},
+		[patch],
+	)
+
+	const setPlanChoice = useCallback(
+		(choice: PlanChoice) => {
+			try {
+				localStorage.setItem(STORAGE_PLAN, choice)
+			} catch {
+				/* private mode */
+			}
+			patch({ planChoice: choice })
+		},
+		[patch],
+	)
+
+	// ---- transcription queue ----------------------------------------------
+	const notifyDrained = () => {
+		if (queueRef.current.length === 0 && inFlightRef.current === null && decodingRef.current === 0) {
+			drainWaitersRef.current.forEach((fn) => fn())
+			drainWaitersRef.current = []
+		}
+	}
+
+	const pump = useCallback(async () => {
+		if (inFlightRef.current !== null) return
+		const index = queueRef.current.shift()
+		if (index === undefined) {
+			notifyDrained()
+			return
+		}
+		inFlightRef.current = index
+		const meetingId = meetingIdRef.current
+		const record = chunksRef.current.get(index)
+		try {
+			await parakeetReady.current
+			const worker = parakeetRef.current
+			if (!worker || !record || !meetingId) throw new Error('Parakeet is not available')
+			const result = await new Promise<Extract<ParakeetWorkerResponse, { type: 'transcribed' }>>((resolve, reject) => {
+				pendingResolvers.current.set(index, { resolve, reject })
+				const audio = record.pcm.slice()
+				worker.postMessage({ type: 'transcribe', id: index, audio, sampleRate: SAMPLE_RATE } satisfies ParakeetWorkerRequest, [audio.buffer])
+			})
+			record.text = result.text
+			record.segments = wordsToSegments(result.words, result.text, result.audioSeconds)
+			patch((s) => ({
+				transcription: {
+					done: s.transcription.done + 1,
+					queued: Math.max(0, s.transcription.queued - 1),
+					audioSeconds: s.transcription.audioSeconds + result.audioSeconds,
+					processMs: s.transcription.processMs + result.ms,
+				},
+			}))
+			try {
+				await putChunkTranscript(meetingId, index, result.text, record.segments, result.audioSeconds)
+			} catch (err) {
+				console.warn('Retrying chunk transcript upload once:', err)
+				await putChunkTranscript(meetingId, index, result.text, record.segments, result.audioSeconds).catch((e) => console.error(e))
+			}
+		} catch (err) {
+			console.error(`On-device transcription failed for chunk ${index}:`, err)
+			if (record) record.text = record.text ?? ''
+			patch((s) => ({ transcription: { ...s.transcription, queued: Math.max(0, s.transcription.queued - 1) } }))
+		} finally {
+			inFlightRef.current = null
+			void pump()
+		}
+	}, [patch])
+
+	const beginMeeting = useCallback(
+		(meetingId: string) => {
+			meetingIdRef.current = meetingId
+			chunksRef.current = new Map()
+			queueRef.current = []
+			inFlightRef.current = null
+			decodingRef.current = 0
+			drainWaitersRef.current = []
+			patch({
+				transcription: { done: 0, queued: 0, audioSeconds: 0, processMs: 0 },
+				diarization: { ...stateRef.current.diarization, stage: null, done: 0, total: 0, ms: null, speakers: null },
+			})
+		},
+		[patch],
+	)
+
+	const addChunk = useCallback(
+		(blob: Blob, index: number) => {
+			if (!meetingIdRef.current) return
+			decodingRef.current += 1
+			patch((s) => ({ transcription: { ...s.transcription, queued: s.transcription.queued + 1 } }))
+			decodeToPcm(blob)
+				.then((pcm) => {
+					chunksRef.current.set(index, { pcm, text: null, segments: [] })
+					queueRef.current.push(index)
+				})
+				.catch((err) => {
+					console.error(`Could not decode chunk ${index}:`, err)
+					patch((s) => ({ transcription: { ...s.transcription, queued: Math.max(0, s.transcription.queued - 1) } }))
+				})
+				.finally(() => {
+					decodingRef.current -= 1
+					void pump()
+				})
+		},
+		[patch, pump],
+	)
+
+	const waitForDrain = () =>
+		new Promise<void>((resolve) => {
+			if (queueRef.current.length === 0 && inFlightRef.current === null && decodingRef.current === 0) resolve()
+			else drainWaitersRef.current.push(resolve)
+		})
+
+	// ---- finish: diarize + hand over ---------------------------------------
+	const finish = useCallback(async () => {
+		const meetingId = meetingIdRef.current
+		if (!meetingId) return
+		const heartbeat = setInterval(() => {
+			fetch(apiUrl(`/api/meetings/${meetingId}/heartbeat`), { method: 'POST' }).catch(() => {})
+		}, 60_000)
+
+		try {
+			await waitForDrain()
+			await parakeetReady.current?.catch(() => null)
+			if (!parakeetRef.current || stateRef.current.phase === 'error' || stateRef.current.phase === 'fallback') {
+				throw new Error(stateRef.current.error ?? 'Parakeet did not load')
+			}
+
+			// Concatenate every decoded chunk, in order, remembering offsets.
+			const indexes = Array.from(chunksRef.current.keys()).sort((a, b) => a - b)
+			let totalSamples = 0
+			for (const i of indexes) totalSamples += chunksRef.current.get(i)!.pcm.length
+			const audio = new Float32Array(totalSamples)
+			const chunks: TranscriptChunk[] = []
+			let cursor = 0
+			for (const i of indexes) {
+				const rec = chunksRef.current.get(i)!
+				audio.set(rec.pcm, cursor)
+				chunks.push({ index: i, text: rec.text ?? '', segments: rec.segments, offset: cursor / SAMPLE_RATE })
+				cursor += rec.pcm.length
+			}
+			const durationSeconds = Math.round(totalSamples / SAMPLE_RATE)
+
+			let turns: SpeakerTurn[] = []
+			let speakers: number | null = null
+			let diarizationMs: number | null = null
+			patch((s) => ({ phase: 'diarizing', diarization: { ...s.diarization, stage: 'segmenting', done: 0, total: 0 } }))
+			try {
+				await diarizerReady.current
+				const worker = diarizerRef.current
+				const manifest = manifestRef.current
+				if (!worker || !manifest) throw new Error('diarization models unavailable')
+				const raw = await new Promise<{ turns: SpeakerTurn[]; ms: number }>((resolve, reject) => {
+					worker.onmessage = (event: MessageEvent<DiarizationWorkerResponse>) => {
+						const msg = event.data
+						if (msg.type === 'progress') patch((s) => ({ diarization: { ...s.diarization, stage: msg.progress.stage, done: msg.progress.done, total: msg.progress.total } }))
+						else if (msg.type === 'result') resolve({ turns: msg.turns, ms: msg.ms })
+						else if (msg.type === 'error') reject(new Error(msg.message))
+					}
+					worker.onerror = (e) => reject(new Error(e.message))
+					const cfg = manifest.config
+					worker.postMessage(
+						{
+							type: 'run',
+							audio,
+							config: { windowShiftRatio: cfg.window_shift_ratio, clusterThreshold: cfg.cluster_threshold, minDurationOn: cfg.min_duration_on, minDurationOff: cfg.min_duration_off },
+						} satisfies DiarizationWorkerRequest,
+						[audio.buffer],
+					)
+				})
+				diarizationMs = raw.ms
+				const [renumbered, count] = renumberByFirstAppearance(pruneMinorSpeakers(raw.turns, manifest.config.min_speaker_share))
+				turns = renumbered
+				speakers = count
+			} catch (err) {
+				console.warn('On-device diarization failed; sending the plain transcript.', err)
+			}
+			patch((s) => ({ diarization: { ...s.diarization, stage: null, ms: diarizationMs, speakers } }))
+
+			const transcript = turns.length > 0 ? labelTranscript(chunks, turns) : chunks.map((c) => c.text).filter(Boolean).join(' ').trim()
+
+			const s = stateRef.current
+			const clientStats = {
+				plan: s.plan,
+				backend: s.backend,
+				threads: s.threads,
+				download: s.download ? { bytes: s.download.total, ms: s.download.total > 0 ? Math.round(s.download.loaded / Math.max(s.download.bytesPerSec, 1) * 1000) : 0, cached: s.download.total === 0 } : null,
+				model_load_ms: s.modelLoadMs,
+				transcription: { chunks: s.transcription.done, audio_seconds: Math.round(s.transcription.audioSeconds), process_ms: Math.round(s.transcription.processMs) },
+				diarization: { audio_seconds: durationSeconds, ms: diarizationMs === null ? null : Math.round(diarizationMs), speakers, model_bytes: s.diarization.modelBytes, model_load_ms: s.diarization.modelLoadMs },
+				device: { webgpu: s.caps?.webgpu ?? null, fp16: s.caps?.fp16 ?? null, cross_origin_isolated: s.caps?.crossOriginIsolated ?? null, cores: s.caps?.cores ?? null, memory_gb: s.caps?.memoryGb ?? null, mobile: s.caps?.isMobile ?? null, user_agent: navigator.userAgent },
+			}
+
+			patch({ phase: 'finalizing' })
+			await finalizeMeeting(meetingId, { transcript, speaker_count: speakers, duration_seconds: durationSeconds, client_stats: clientStats })
+		} catch (err) {
+			// Anything unrecoverable: let the server pipeline take the audio it already has.
+			console.error('On-device processing failed; falling back to the server.', err)
+			patch({ phase: 'fallback', error: err instanceof Error ? err.message : String(err) })
+			await requestServerFallback(meetingId)
+		} finally {
+			clearInterval(heartbeat)
+			meetingIdRef.current = null
+			chunksRef.current = new Map()
+		}
+	}, [patch])
+
+	// A failed load while a meeting is running means the server must take over.
+	useEffect(() => {
+		if (state.phase === 'error' && meetingIdRef.current) {
+			const id = meetingIdRef.current
+			meetingIdRef.current = null
+			patch({ phase: 'fallback' })
+			requestServerFallback(id).catch(console.error)
+		}
+	}, [state.phase, patch])
+
+	const isUsable = state.enabled && state.phase !== 'error' && state.phase !== 'fallback' && state.phase !== 'idle'
+	const localStage = state.phase === 'diarizing' ? 'diarizing' : state.phase === 'finalizing' ? 'summarizing' : null
+
+	return { state: { ...state, plan }, setEnabled, setPlanChoice, isUsable, beginMeeting, addChunk, finish, localStage }
+}

--- a/frontend/src/ondevice/useOnDevice.ts
+++ b/frontend/src/ondevice/useOnDevice.ts
@@ -32,7 +32,12 @@ export interface DownloadState {
 	total: number
 	startedAt: number
 	bytesPerSec: number
+	/** Every file is on disk; the model is now being loaded into memory. */
 	done: boolean
+	/** All files came from the on-disk cache (no network). */
+	cached: boolean
+	/** When `done` flipped, so the panel can show how long loading takes. */
+	doneAt: number | null
 }
 
 export interface OnDeviceState {
@@ -43,6 +48,13 @@ export interface OnDeviceState {
 	phase: OnDevicePhase
 	error: string | null
 	download: DownloadState | null
+	/** Worker's own description of what it is doing right now. */
+	statusText: string | null
+	/** Last console lines from the worker (parakeet.js / ORT), newest last. */
+	log: string[]
+	/** Set when the GPU plan failed and the CPU plan was loaded instead. */
+	autoFallbackPlan: ParakeetPlan | null
+	autoFallbackReason: string | null
 	modelLoadMs: number | null
 	backend: 'webgpu' | 'wasm' | null
 	threads: number | null
@@ -85,6 +97,10 @@ const initialState = (): OnDeviceState => ({
 	phase: 'idle',
 	error: null,
 	download: null,
+	statusText: null,
+	log: [],
+	autoFallbackPlan: null,
+	autoFallbackReason: null,
 	modelLoadMs: null,
 	backend: null,
 	threads: null,
@@ -173,7 +189,11 @@ export function useOnDevice(): OnDeviceController {
 		detectCapabilities().then((caps) => patch({ caps }))
 	}, [patch])
 
-	const plan = useMemo(() => (state.caps ? resolvePlan(state.planChoice, state.caps) : null), [state.caps, state.planChoice])
+	const plan = useMemo(() => {
+		if (!state.caps) return null
+		if (state.planChoice === 'auto' && state.autoFallbackPlan) return state.autoFallbackPlan
+		return resolvePlan(state.planChoice, state.caps)
+	}, [state.caps, state.planChoice, state.autoFallbackPlan])
 
 	// ---- workers -----------------------------------------------------------
 	const terminateWorkers = useCallback(() => {
@@ -188,10 +208,20 @@ export function useOnDevice(): OnDeviceController {
 	const loadWorkers = useCallback(
 		(chosen: ParakeetPlan) => {
 			terminateWorkers()
-			patch({ phase: 'loading', error: null, plan: chosen, download: null, modelLoadMs: null, backend: null })
+			patch({ phase: 'loading', error: null, plan: chosen, download: null, statusText: null, log: [], modelLoadMs: null, backend: null })
 
 			const parakeet = new Worker(new URL('./parakeet.worker.ts', import.meta.url), { type: 'module' })
 			parakeetRef.current = parakeet
+			const fail = (message: string) => {
+				// The GPU plan can fail for reasons the CPU plan does not share
+				// (fp16 files missing, GPU memory, driver quirks). When the plan
+				// was picked automatically, try the CPU one before giving up.
+				if (chosen === 'gpu-fp16' && stateRef.current.planChoice === 'auto' && !stateRef.current.autoFallbackPlan) {
+					patch({ autoFallbackPlan: 'cpu-int8', autoFallbackReason: message })
+					return
+				}
+				patch({ phase: 'error', error: `Parakeet failed to load: ${message} — flip the switch off and on to retry, or pick the other plan.` })
+			}
 			parakeetReady.current = new Promise<void>((resolve, reject) => {
 				parakeet.onmessage = (event: MessageEvent<ParakeetWorkerResponse>) => {
 					const msg = event.data
@@ -201,15 +231,26 @@ export function useOnDevice(): OnDeviceController {
 							const total = Object.values(msg.files).reduce((sum, f) => sum + f.total, 0)
 							const startedAt = s.download?.startedAt ?? Date.now()
 							const elapsed = (Date.now() - startedAt) / 1000
-							return { download: { loaded, total, startedAt, bytesPerSec: elapsed > 0.5 ? loaded / elapsed : 0, done: false } }
+							return { download: { loaded, total, startedAt, bytesPerSec: elapsed > 0.5 ? loaded / elapsed : 0, done: false, cached: msg.cached, doneAt: null } }
 						})
+					} else if (msg.type === 'status') {
+						patch((s) => ({
+							statusText: msg.text,
+							// The first status after the last byte marks the start of the load-into-memory step.
+							download: s.download && !s.download.done && s.download.loaded >= s.download.total && s.download.total > 0 ? { ...s.download, done: true, doneAt: Date.now() } : s.download,
+						}))
+					} else if (msg.type === 'log') {
+						patch((s) => ({ log: [...s.log.slice(-29), `${msg.level === 'error' ? '❌ ' : msg.level === 'warn' ? '⚠️ ' : ''}${msg.text}`] }))
 					} else if (msg.type === 'loaded') {
 						patch((s) => ({
 							phase: 'ready',
+							statusText: null,
 							modelLoadMs: msg.loadMs,
 							backend: msg.backend,
 							threads: msg.threads,
-							download: s.download ? { ...s.download, done: true } : { loaded: 0, total: 0, startedAt: Date.now(), bytesPerSec: 0, done: true },
+							download: s.download
+								? { ...s.download, done: true, cached: msg.cached, loaded: msg.downloadBytes, total: msg.downloadBytes }
+								: { loaded: msg.downloadBytes, total: msg.downloadBytes, startedAt: Date.now(), bytesPerSec: 0, done: true, cached: msg.cached, doneAt: Date.now() },
 						}))
 						resolve()
 					} else if (msg.type === 'transcribed') {
@@ -220,18 +261,19 @@ export function useOnDevice(): OnDeviceController {
 							pendingResolvers.current.get(msg.id)?.reject(new Error(msg.message))
 							pendingResolvers.current.delete(msg.id)
 						} else {
-							patch({ phase: 'error', error: `Parakeet failed to load: ${msg.message} — flip the switch off and on to retry.` })
+							fail(`${msg.stage ? `${msg.stage}: ` : ''}${msg.message}`)
 							reject(new Error(msg.message))
 						}
 					}
 				}
 				parakeet.onerror = (e) => {
-					patch({ phase: 'error', error: `Parakeet worker crashed: ${e.message}` })
+					fail(`worker crashed: ${e.message}`)
 					reject(new Error(e.message))
 				}
 			})
 			parakeetReady.current.catch(() => {})
-			parakeet.postMessage({ type: 'load', plan: chosen } satisfies ParakeetWorkerRequest)
+			const modelBase = (import.meta.env.VITE_PARAKEET_MODEL_BASE as string | undefined) || undefined
+			parakeet.postMessage({ type: 'load', plan: chosen, modelBase } satisfies ParakeetWorkerRequest)
 
 			const diarizer = new Worker(new URL('./diarization.worker.ts', import.meta.url), { type: 'module' })
 			diarizerRef.current = diarizer
@@ -263,7 +305,7 @@ export function useOnDevice(): OnDeviceController {
 		if (!state.enabled) {
 			if (state.phase !== 'idle' || state.plan !== null) {
 				terminateWorkers()
-				patch({ phase: 'idle', error: null, download: null, plan: null })
+				patch({ phase: 'idle', error: null, download: null, plan: null, statusText: null, log: [], autoFallbackPlan: null, autoFallbackReason: null })
 			}
 			return
 		}
@@ -295,7 +337,7 @@ export function useOnDevice(): OnDeviceController {
 			} catch {
 				/* private mode */
 			}
-			patch({ planChoice: choice })
+			patch({ planChoice: choice, autoFallbackPlan: null, autoFallbackReason: null })
 		},
 		[patch],
 	)
@@ -470,7 +512,7 @@ export function useOnDevice(): OnDeviceController {
 				plan: s.plan,
 				backend: s.backend,
 				threads: s.threads,
-				download: s.download ? { bytes: s.download.total, ms: s.download.total > 0 ? Math.round(s.download.loaded / Math.max(s.download.bytesPerSec, 1) * 1000) : 0, cached: s.download.total === 0 } : null,
+				download: s.download ? { bytes: s.download.total, ms: s.download.cached ? 0 : Math.round((s.download.loaded / Math.max(s.download.bytesPerSec, 1)) * 1000), cached: s.download.cached } : null,
 				model_load_ms: s.modelLoadMs,
 				transcription: { chunks: s.transcription.done, audio_seconds: Math.round(s.transcription.audioSeconds), process_ms: Math.round(s.transcription.processMs) },
 				diarization: { audio_seconds: durationSeconds, ms: diarizationMs === null ? null : Math.round(diarizationMs), speakers, model_bytes: s.diarization.modelBytes, model_load_ms: s.diarization.modelLoadMs },

--- a/frontend/src/pages/Record.tsx
+++ b/frontend/src/pages/Record.tsx
@@ -14,6 +14,8 @@ import HistoryList from '../components/HistoryList'
 import InfoPanel, { InfoButton } from '../components/InfoPanel'
 import LanguageSelector from '../components/LanguageSelector'
 import { useSummaryLanguage, SummaryLanguageState } from '../contexts/SummaryLanguageContext'
+import { useOnDevice } from '../ondevice/useOnDevice'
+import OnDevicePanel from '../components/OnDevicePanel'
 
 export default function Record() {
 	const { theme } = useTheme()
@@ -21,6 +23,7 @@ export default function Record() {
 	const { summaryLength, setSummaryLength } = useSummaryLength()
 	const { languageState, setLanguageState } = useSummaryLanguage()
 	const [context, setContext] = useState('')
+	const onDevice = useOnDevice()
 
 	const {
 		isRecording,
@@ -51,7 +54,7 @@ export default function Record() {
 		updateContext,
 		updateMeetingConfig,
 		wakeLockStatus,
-	} = useRecording(summaryLength, languageState)
+	} = useRecording(summaryLength, languageState, onDevice)
 
 	const [history, setHistory] = useState<MeetingMeta[]>([])
 	const [infoOpen, setInfoOpen] = useState(false)
@@ -265,8 +268,11 @@ export default function Record() {
 							<FileUpload selectedFile={selectedFile} onFileSelect={setSelectedFile} disabled={isUiLocked} theme={currentThemeColors} />
 						</div>
 					)}
+					{audioSource !== 'file' && <OnDevicePanel controller={onDevice} theme={currentThemeColors} locked={false} />}
 				</>
 			)}
+
+			{isUiLocked && onDevice.state.enabled && audioSource !== 'file' && <OnDevicePanel controller={onDevice} theme={currentThemeColors} locked={true} />}
 
 			{isRecording && (
 				<div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginBottom: '10px' }}>

--- a/frontend/src/pages/Summary.tsx
+++ b/frontend/src/pages/Summary.tsx
@@ -18,6 +18,7 @@ import { isFavorite as checkFavorite, toggleFavorite, getMeetingTagIds, toggleMe
 import SummaryLengthSelector from '../components/SummaryLengthSelector'
 import LanguageSelector from '../components/LanguageSelector'
 import { useMeetingSummary } from '../hooks/useMeetingSummary'
+import OnDeviceStats from '../components/OnDeviceStats'
 import { useSummaryLanguage, SummaryLanguageState } from '../contexts/SummaryLanguageContext'
 import { SummaryLength } from '../contexts/SummaryLengthContext'
 
@@ -50,6 +51,7 @@ export default function Summary() {
 		canRediarize,
 		diarizationAttempted,
 		speakerCount,
+		clientStats,
 		processingStage,
 		processingTotal,
 		handleRediarize,
@@ -678,6 +680,7 @@ export default function Summary() {
 									{speakerCount} {speakerCount === 1 ? 'speaker' : 'speakers'}
 								</span>
 							) : null}
+							{clientStats ? <span style={{ marginLeft: '8px', fontSize: '12px' }} title="Transcribed on the recording device">⚡</span> : null}
 						</span>
 						<button
 							onClick={(e) => {
@@ -706,6 +709,7 @@ export default function Summary() {
 							{transcriptCopied ? <span>Copied!</span> : <CopyTextIcon size={13} />}
 						</button>
 					</h5>
+					{clientStats && <OnDeviceStats stats={clientStats} theme={currentThemeColors} />}
 					{isTranscriptVisible && (
 						<pre style={{ marginTop: '8px', whiteSpace: 'pre-wrap', color: currentThemeColors.text, fontSize: '15px', lineHeight: '1.6' }}>{transcript}</pre>
 					)}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,10 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [react()],
     build: { outDir: "dist", emptyOutDir: true },
+    // Browser tests swap the real model for a fake one (no 600 MB download).
+    ...(process.env.PARAKEET_MOCK === "1"
+      ? { resolve: { alias: { "parakeet.js": path.resolve(process.cwd(), "src/ondevice/testing/parakeetMock.ts") } } }
+      : {}),
     define: {
       // env.VITE_API_BASE_URL comes from the root .env file (local dev).
       // process.env.VITE_API_BASE_URL is the fallback for Docker builds where
@@ -15,7 +19,16 @@ export default defineConfig(({ mode }) => {
         env.VITE_API_BASE_URL ?? process.env.VITE_API_BASE_URL ?? ''
       )
     },
+    // Module workers so the on-device workers can import npm packages.
+    worker: { format: "es" },
     server: {
+      // Cross-origin isolation gives the page SharedArrayBuffer, which lets
+      // ONNX Runtime run WASM multi-threaded (on-device transcription and
+      // diarization). Mirrored in nginx.conf for production.
+      headers: {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+      },
       proxy: {
         '/api': 'http://localhost:8000'
       }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,28 @@
 import path from "path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
+
+// The ESM WebGPU-EP entry of *this* package's onnxruntime-web.
+const ORT_WEBGPU_ENTRY = fileURLToPath(import.meta.resolve("onnxruntime-web/webgpu"));
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, path.resolve(process.cwd(), ".."), "");
   return {
     plugins: [react()],
     build: { outDir: "dist", emptyOutDir: true },
+    resolve: {
+      alias: [
+        // parakeet.js does its own `import('onnxruntime-web')` and pins 1.24.1
+        // as a dependency, so it would load a second ORT — an older one, whose
+        // JSEP MatMulNBits kernel is 4-bit only. Redirect it to the very file
+        // src/ondevice/ortSetup.ts loads, resolved absolutely: a bare
+        // "onnxruntime-web/webgpu" would resolve again from parakeet.js's own
+        // nested copy. Anchored, so this package's own subpath imports (the
+        // /webgpu entry, the ?url wasm) are left alone.
+        { find: /^onnxruntime-web$/, replacement: ORT_WEBGPU_ENTRY },
+      ],
+    },
     // Browser tests swap the real model for a fake one (no 600 MB download).
     ...(process.env.PARAKEET_MOCK === "1"
       ? { resolve: { alias: { "parakeet.js": path.resolve(process.cwd(), "src/ondevice/testing/parakeetMock.ts") } } }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -37,6 +37,15 @@ export default defineConfig(({ mode }) => {
       proxy: {
         '/api': 'http://localhost:8000'
       }
+    },
+    preview: {
+      headers: {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+      },
+      proxy: {
+        '/api': 'http://localhost:8000'
+      }
     }
   }
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,11 @@ export default defineConfig(({ mode }) => {
       // the value is injected as a build arg (ARG/ENV in Dockerfile).
       'import.meta.env.VITE_API_BASE_URL': JSON.stringify(
         env.VITE_API_BASE_URL ?? process.env.VITE_API_BASE_URL ?? ''
+      ),
+      // Optional: self-host the Parakeet model files (same names as the
+      // Hugging Face repo) instead of downloading them from Hugging Face.
+      'import.meta.env.VITE_PARAKEET_MODEL_BASE': JSON.stringify(
+        env.VITE_PARAKEET_MODEL_BASE ?? process.env.VITE_PARAKEET_MODEL_BASE ?? ''
       )
     },
     // Module workers so the on-device workers can import npm packages.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^17.0.5
         version: 17.0.6
       onnxruntime-web:
-        specifier: 1.24.1
-        version: 1.24.1
+        specifier: 1.29.0
+        version: 1.29.0
       parakeet.js:
         specifier: 1.4.4
         version: 1.4.4
@@ -996,8 +996,14 @@ packages:
   onnxruntime-common@1.24.1:
     resolution: {integrity: sha512-UnV15u4p4XxoIV+jFP4hXPsW93s3QrwLSpi20HUDYHoTfI4z4sjzex3L4XDOxGGZJ/M/catrwAG2go958UQq0w==}
 
+  onnxruntime-common@1.29.0:
+    resolution: {integrity: sha512-/F63/e2VJoaVXGGNu6S5QH7jivBThGO95OzAVXXQ8hTta/b1QxI8udHa6cI3+3mAb5WWIIaMMwfZw01oivjJ1g==}
+
   onnxruntime-web@1.24.1:
     resolution: {integrity: sha512-i2u395dv+ZEQBdH+aORvlu19Bzvlg5AXJ7wjxnL350hknOP9z0UeP3pVfjkpMEWMPy2T6nCQxetKTmNia6wSzg==}
+
+  onnxruntime-web@1.29.0:
+    resolution: {integrity: sha512-LuQlpX6MFLJZu756erwUeb1mNfoJGbs1kzDwJGNlf5RvfYMdqhcY3vNpDPK40CUV2HoWTkIj+uS0o36GFHjeYw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2095,12 +2101,23 @@ snapshots:
 
   onnxruntime-common@1.24.1: {}
 
+  onnxruntime-common@1.29.0: {}
+
   onnxruntime-web@1.24.1:
     dependencies:
       flatbuffers: 25.9.23
       guid-typescript: 1.0.9
       long: 5.3.2
       onnxruntime-common: 1.24.1
+      platform: 1.3.6
+      protobufjs: 7.6.6
+
+  onnxruntime-web@1.29.0:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.29.0
       platform: 1.3.6
       protobufjs: 7.6.6
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       marked:
         specifier: ^17.0.5
         version: 17.0.6
+      onnxruntime-web:
+        specifier: 1.24.1
+        version: 1.24.1
+      parakeet.js:
+        specifier: 1.4.4
+        version: 1.4.4
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -376,6 +382,33 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@remix-run/router@1.23.4':
     resolution: {integrity: sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==}
@@ -818,6 +851,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
@@ -841,6 +877,9 @@ packages:
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -917,6 +956,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -951,6 +993,12 @@ packages:
     resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
+  onnxruntime-common@1.24.1:
+    resolution: {integrity: sha512-UnV15u4p4XxoIV+jFP4hXPsW93s3QrwLSpi20HUDYHoTfI4z4sjzex3L4XDOxGGZJ/M/catrwAG2go958UQq0w==}
+
+  onnxruntime-web@1.24.1:
+    resolution: {integrity: sha512-i2u395dv+ZEQBdH+aORvlu19Bzvlg5AXJ7wjxnL350hknOP9z0UeP3pVfjkpMEWMPy2T6nCQxetKTmNia6wSzg==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -962,6 +1010,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  parakeet.js@1.4.4:
+    resolution: {integrity: sha512-+tYIDgp799bvsDye3y2lFyspYHgTOJ5YMZi0mWYABXyJjp/3NZmNaMTnS9jhf4qlIQJoBk0Nmj+UwsI3zk+Aqg==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -982,6 +1033,9 @@ packages:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -994,6 +1048,10 @@ packages:
     resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
+
+  protobufjs@7.6.6:
+    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
+    engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1472,6 +1530,26 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
   '@remix-run/router@1.23.4': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -1914,6 +1992,8 @@ snapshots:
       flatted: 3.4.4
       keyv: 4.5.4
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.4: {}
 
   fsevents@2.3.3:
@@ -1928,6 +2008,8 @@ snapshots:
       is-glob: 4.0.3
 
   globals@14.0.0: {}
+
+  guid-typescript@1.0.9: {}
 
   has-flag@4.0.0: {}
 
@@ -1983,6 +2065,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -2009,6 +2093,17 @@ snapshots:
 
   node-releases@2.0.54: {}
 
+  onnxruntime-common@1.24.1: {}
+
+  onnxruntime-web@1.24.1:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.1
+      platform: 1.3.6
+      protobufjs: 7.6.6
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2026,6 +2121,10 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parakeet.js@1.4.4:
+    dependencies:
+      onnxruntime-web: 1.24.1
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -2038,6 +2137,8 @@ snapshots:
 
   picomatch@4.0.7: {}
 
+  platform@1.3.6: {}
+
   postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
@@ -2047,6 +2148,20 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.9.6: {}
+
+  protobufjs@7.6.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.20.1
+      long: 5.3.2
 
   punycode@2.3.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - frontend
 
 # pnpm blocks dependency build scripts by default; esbuild needs its postinstall
-# to fetch the platform binary that vite depends on.
-onlyBuiltDependencies:
-  - esbuild
+# to fetch the platform binary that vite depends on. protobufjs (pulled in by
+# onnxruntime-web) has a postinstall that only prints a notice, so it stays off.
+allowBuilds:
+  esbuild: true
+  protobufjs: false

--- a/scripts/eval_parakeet_encoders.py
+++ b/scripts/eval_parakeet_encoders.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+scripts/eval_parakeet_encoders.py
+───────────────────────────────────────────────────────────────────────────
+Compares Parakeet encoder builds — fp32, weight-only int8 (MatMulNBits, from
+quantize_parakeet_encoder.py) and the upstream dynamically quantized int8 —
+on the same audio, in the same runtime.
+
+Why not measure in the browser: the two questions that decide whether the
+weight-only build replaces the two-plan setup are about the *weights*, not
+about WebGPU. Both are answerable on the CPU here, in minutes, without
+recording a meeting:
+
+  accuracy  encoder output error, and the transcript each build produces,
+            against the fp32 encoder as reference
+  speed     encoder wall-clock per second of audio, weight-only vs the
+            dynamically quantized file that CPU devices download today
+
+The browser still has the last word on absolute speed (ORT Web on WASM is
+slower than ORT on native CPU), but the *ratio* between two files in one
+runtime carries over.
+
+Feature extraction mirrors parakeet.js/src/mel.js exactly — NeMo's
+preprocessor: pre-emphasis 0.97, 512-point FFT over a 400-sample symmetric
+Hann window, hop 160, 128 slaney mel bins, log(x + 2^-24), then per-feature
+normalization with an N-1 denominator. Decoding mirrors its greedy TDT loop,
+including the two rules that are easy to get wrong: the decoder state only
+advances on a non-blank token, and a duration of 0 keeps you on the frame.
+
+Usage
+─────
+    python scripts/eval_parakeet_encoders.py \
+        --wavs data/eval/wavs \
+        --models data/parakeet-q8 \
+        --encoder fp32=data/parakeet-q8/.src/encoder-model.onnx \
+        --encoder q8=data/parakeet-q8/encoder-model.int8.onnx \
+        --encoder dyn-int8=data/eval/upstream-int8/encoder-model.int8.onnx
+
+The first --encoder is the reference every other one is scored against.
+Audio must be 16 kHz mono WAV.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+import wave
+from pathlib import Path
+
+import numpy as np
+
+SAMPLE_RATE = 16000
+N_FFT = 512
+WIN_LENGTH = 400
+HOP_LENGTH = 160
+PREEMPH = 0.97
+LOG_ZERO_GUARD = 2.0**-24
+N_MELS = 128
+N_FREQ_BINS = N_FFT // 2 + 1
+
+# TDT durations are the tail of the joint's output; the vocabulary is the head.
+DURATION_BINS = 5
+MAX_TOKENS_PER_STEP = 10
+
+F_SP = 200.0 / 3
+MIN_LOG_HZ = 1000.0
+MIN_LOG_MEL = MIN_LOG_HZ / F_SP
+LOG_STEP = np.log(6.4) / 27.0
+
+
+# ── features ───────────────────────────────────────────────────────────────
+def hz_to_mel(f):
+    """Slaney mel scale, as torchaudio's melscale_fbanks(mel_scale="slaney")."""
+    f = np.asarray(f, dtype=np.float64)
+    # np.where evaluates both branches, so keep the log away from 0 Hz.
+    safe = np.maximum(f, MIN_LOG_HZ)
+    return np.where(f >= MIN_LOG_HZ, MIN_LOG_MEL + np.log(safe / MIN_LOG_HZ) / LOG_STEP, f / F_SP)
+
+
+def mel_to_hz(m):
+    m = np.asarray(m, dtype=np.float64)
+    return np.where(m >= MIN_LOG_MEL, MIN_LOG_HZ * np.exp(LOG_STEP * (m - MIN_LOG_MEL)), m * F_SP)
+
+
+def mel_filterbank(n_mels: int = N_MELS) -> np.ndarray:
+    """[n_mels, 257] triangular filters with slaney normalization."""
+    all_freqs = np.linspace(0.0, SAMPLE_RATE / 2, N_FREQ_BINS)
+    pts = mel_to_hz(np.linspace(float(hz_to_mel(0.0)), float(hz_to_mel(SAMPLE_RATE / 2.0)), n_mels + 2))
+    diff = np.diff(pts)
+    fb = np.zeros((n_mels, N_FREQ_BINS), dtype=np.float64)
+    for m in range(n_mels):
+        down = (all_freqs - pts[m]) / diff[m]
+        up = (pts[m + 2] - all_freqs) / diff[m + 1]
+        fb[m] = np.maximum(0.0, np.minimum(down, up)) * (2.0 / (pts[m + 2] - pts[m]))
+    return fb.astype(np.float32)
+
+
+_FB = mel_filterbank()
+# Symmetric (periodic=False) Hann over 400 samples, zero-padded into 512.
+_WINDOW = np.zeros(N_FFT, dtype=np.float64)
+_WINDOW[:WIN_LENGTH] = np.hanning(WIN_LENGTH)
+
+
+def log_mel(audio: np.ndarray) -> np.ndarray:
+    """16 kHz mono float32 samples -> normalized log-mel [128, frames]."""
+    n = len(audio)
+    pad = N_FFT // 2
+    padded = np.zeros(n + N_FFT, dtype=np.float32)
+    padded[pad] = audio[0]
+    padded[pad + 1 : pad + n] = (audio[1:] - PREEMPH * audio[:-1]).astype(np.float32)
+
+    frames = (len(padded) - N_FFT) // HOP_LENGTH + 1
+    idx = np.arange(frames)[:, None] * HOP_LENGTH + np.arange(N_FFT)[None, :]
+    windowed = padded[idx].astype(np.float64) * _WINDOW
+    spec = np.fft.rfft(windowed, n=N_FFT, axis=1)
+    power = (spec.real**2 + spec.imag**2).astype(np.float32)  # [frames, 257]
+
+    mel = np.log(power @ _FB.T + LOG_ZERO_GUARD).T  # [128, frames]
+    mean = mel.mean(axis=1, keepdims=True)
+    std = mel.std(axis=1, ddof=1, keepdims=True) if frames > 1 else np.ones_like(mean)
+    return ((mel - mean) / (std + 1e-5)).astype(np.float32)
+
+
+def read_wav(path: Path) -> np.ndarray:
+    with wave.open(str(path), "rb") as wf:
+        if wf.getframerate() != SAMPLE_RATE or wf.getnchannels() != 1 or wf.getsampwidth() != 2:
+            raise SystemExit(f"{path.name}: need 16 kHz mono 16-bit WAV, got {wf.getframerate()} Hz / {wf.getnchannels()} ch / {wf.getsampwidth() * 8}-bit")
+        pcm = np.frombuffer(wf.readframes(wf.getnframes()), dtype="<i2")
+    return (pcm.astype(np.float32) / 32768.0).astype(np.float32)
+
+
+# ── tokenizer ──────────────────────────────────────────────────────────────
+class Tokenizer:
+    """vocab.txt is "<token> <id>" per line, as parakeet.js reads it."""
+
+    def __init__(self, vocab_path: Path):
+        tokens: dict[int, str] = {}
+        for line in vocab_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            tok, _, idx = line.rpartition(" ")
+            tokens[int(idx)] = tok
+        self.id2token = [tokens.get(i, "") for i in range(max(tokens) + 1)]
+        self.blank_id = self.id2token.index("<blk>")
+
+    def decode(self, ids: list[int]) -> str:
+        text = "".join(self.id2token[i].replace("▁", " ") for i in ids if i != self.blank_id)
+        text = re.sub(r"^\s+", "", text)
+        text = re.sub(r"\s+(?=[^\w\s])", "", text)
+        return re.sub(r"\s+", " ", text).strip()
+
+
+# ── decoding ───────────────────────────────────────────────────────────────
+def greedy_tdt(joint, encoded: np.ndarray, vocab_size: int, blank_id: int) -> list[int]:
+    """Greedy TDT decode of one utterance. `encoded` is [1, D, T]."""
+    t_total = encoded.shape[2]
+    state1 = np.zeros((2, 1, 640), dtype=np.float32)
+    state2 = np.zeros((2, 1, 640), dtype=np.float32)
+    target_length = np.array([1], dtype=np.int32)
+
+    ids: list[int] = []
+    t, emitted = 0, 0
+    while t < t_total:
+        frame = np.ascontiguousarray(encoded[:, :, t : t + 1])
+        prev = ids[-1] if ids else blank_id
+        outputs, _, out1, out2 = joint.run(
+            None,
+            {
+                "encoder_outputs": frame,
+                "targets": np.array([[prev]], dtype=np.int32),
+                "target_length": target_length,
+                "input_states_1": state1,
+                "input_states_2": state2,
+            },
+        )
+        logits = outputs.reshape(-1)
+        token_id = int(np.argmax(logits[:vocab_size]))
+        step = int(np.argmax(logits[vocab_size : vocab_size + DURATION_BINS]))
+
+        if token_id != blank_id:
+            # Only a non-blank emission advances the decoder state.
+            state1, state2 = out1, out2
+            ids.append(token_id)
+            emitted += 1
+
+        if step > 0:
+            t += step
+            emitted = 0
+        elif token_id == blank_id or emitted >= MAX_TOKENS_PER_STEP:
+            t += 1
+            emitted = 0
+        # A duration of 0 on a non-blank token deliberately stays on the frame.
+    return ids
+
+
+# ── scoring ────────────────────────────────────────────────────────────────
+def wer(reference: str, hypothesis: str) -> tuple[float, int, int, int, int]:
+    """Levenshtein over words: (rate, substitutions, deletions, insertions, N)."""
+    ref, hyp = reference.lower().split(), hypothesis.lower().split()
+    # Each cell carries (cost, substitutions, deletions, insertions).
+    prev: list[tuple[float, int, int, int]] = [(j, 0, 0, j) for j in range(len(hyp) + 1)]
+    for i in range(1, len(ref) + 1):
+        cur: list[tuple[float, int, int, int]] = [(i, 0, i, 0)] + [(float("inf"), 0, 0, 0)] * len(hyp)
+        for j in range(1, len(hyp) + 1):
+            if ref[i - 1] == hyp[j - 1]:
+                cur[j] = prev[j - 1]
+            else:
+                sub = (prev[j - 1][0] + 1, prev[j - 1][1] + 1, prev[j - 1][2], prev[j - 1][3])
+                dele = (prev[j][0] + 1, prev[j][1], prev[j][2] + 1, prev[j][3])
+                ins = (cur[j - 1][0] + 1, cur[j - 1][1], cur[j - 1][2], cur[j - 1][3] + 1)
+                cur[j] = min(sub, dele, ins, key=lambda x: x[0])
+        prev = cur
+    cost, subs, dels, inss = prev[-1]
+    return cost / max(1, len(ref)), subs, dels, inss, len(ref)
+
+
+def rel_error(reference: np.ndarray, other: np.ndarray) -> float:
+    """||other - reference|| / ||reference||, over the common frame span."""
+    t = min(reference.shape[2], other.shape[2])
+    a, b = reference[:, :, :t].astype(np.float64), other[:, :, :t].astype(np.float64)
+    denom = np.linalg.norm(a)
+    return float(np.linalg.norm(b - a) / denom) if denom else float("nan")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--wavs", type=Path, required=True, help="directory of 16 kHz mono WAV files")
+    parser.add_argument("--models", type=Path, required=True, help="directory holding decoder_joint-model.int8.onnx and vocab.txt")
+    parser.add_argument("--encoder", action="append", required=True, metavar="LABEL=PATH", help="encoder to evaluate; the first is the reference")
+    parser.add_argument("--threads", type=int, default=0, help="intra-op threads (0 = ORT default)")
+    parser.add_argument("--json", type=Path, default=None, help="also write the results here")
+    args = parser.parse_args()
+
+    import onnxruntime as ort
+
+    encoders: list[tuple[str, Path]] = []
+    for spec in args.encoder:
+        label, _, path = spec.partition("=")
+        if not path:
+            raise SystemExit(f"--encoder wants LABEL=PATH, got {spec!r}")
+        p = Path(path)
+        if not p.exists():
+            raise SystemExit(f"no such encoder: {p}")
+        encoders.append((label, p))
+
+    wavs = sorted(p for p in args.wavs.iterdir() if p.suffix.lower() == ".wav")
+    if not wavs:
+        raise SystemExit(f"no .wav files in {args.wavs}")
+
+    tokenizer = Tokenizer(args.models / "vocab.txt")
+    vocab_size = len(tokenizer.id2token)
+
+    opts = ort.SessionOptions()
+    if args.threads:
+        opts.intra_op_num_threads = args.threads
+    joint = ort.InferenceSession(str(args.models / "decoder_joint-model.int8.onnx"), opts, providers=["CPUExecutionProvider"])
+
+    print("Extracting features")
+    features: dict[str, tuple[np.ndarray, float]] = {}
+    total_seconds = 0.0
+    for wav in wavs:
+        audio = read_wav(wav)
+        seconds = len(audio) / SAMPLE_RATE
+        total_seconds += seconds
+        features[wav.name] = (log_mel(audio), seconds)
+        print(f"  {wav.name:14} {seconds:6.2f} s -> {features[wav.name][0].shape[1]:5} frames")
+    print(f"  {'total':14} {total_seconds:6.2f} s\n")
+
+    results: dict[str, dict] = {}
+    reference_label = encoders[0][0]
+
+    for label, path in encoders:
+        size_mb = path.stat().st_size / 1e6
+        data = path.with_suffix(path.suffix + ".data")
+        if data.exists():
+            size_mb += data.stat().st_size / 1e6
+        print(f"-- {label}  ({path.name}, {size_mb:.0f} MB)")
+        load_start = time.perf_counter()
+        session = ort.InferenceSession(str(path), opts, providers=["CPUExecutionProvider"])
+        length_is_int32 = session.get_inputs()[1].type == "tensor(int32)"
+        print(f"   session ready in {time.perf_counter() - load_start:.1f} s")
+
+        per_clip: dict[str, dict] = {}
+        encoder_seconds = 0.0
+        for wav in wavs:
+            mel, seconds = features[wav.name]
+            length = np.array([mel.shape[1]], dtype=np.int32 if length_is_int32 else np.int64)
+            t0 = time.perf_counter()
+            encoded, _ = session.run(None, {"audio_signal": mel[None, :, :], "length": length})
+            elapsed = time.perf_counter() - t0
+            encoder_seconds += elapsed
+            text = tokenizer.decode(greedy_tdt(joint, encoded, vocab_size, tokenizer.blank_id))
+            per_clip[wav.name] = {"seconds": seconds, "encoder_s": elapsed, "encoded": encoded, "text": text}
+            print(f"   {wav.name:14} enc {elapsed:6.2f} s ({seconds / elapsed:5.1f}x)  {text[:70]}")
+
+        results[label] = {
+            "path": str(path),
+            "size_mb": round(size_mb, 1),
+            "encoder_s": round(encoder_seconds, 2),
+            "realtime_x": round(total_seconds / encoder_seconds, 2),
+            "clips": per_clip,
+        }
+        print(f"   encoder total {encoder_seconds:.2f} s for {total_seconds:.2f} s audio = {total_seconds / encoder_seconds:.1f}x realtime\n")
+
+    print(f"== against {reference_label} ==")
+    reference = results[reference_label]
+    print(f"{'build':12} {'size':>8} {'speed':>9} {'enc err':>9} {'WER':>8}   sub/del/ins")
+    for label, res in results.items():
+        errors = []
+        subs = dels = inss = cost = ref_words = 0
+        for name, clip in res["clips"].items():
+            ref_clip = reference["clips"][name]
+            errors.append(rel_error(ref_clip["encoded"], clip["encoded"]))
+            _, s, d, i, n = wer(ref_clip["text"], clip["text"])
+            subs, dels, inss, ref_words, cost = subs + s, dels + d, inss + i, ref_words + n, cost + s + d + i
+        overall = cost / max(1, ref_words)
+        res["encoder_rel_error"] = round(float(np.mean(errors)), 5)
+        res["wer_vs_reference"] = round(overall, 5)
+        res["errors"] = {"substitutions": subs, "deletions": dels, "insertions": inss, "reference_words": ref_words}
+        print(f"{label:12} {res['size_mb']:7.0f}M {res['realtime_x']:8.1f}x {np.mean(errors) * 100:8.2f}% {overall * 100:7.2f}%   {subs}/{dels}/{inss}")
+
+    print("\nTranscripts")
+    for wav in wavs:
+        print(f"  {wav.name}")
+        for label, res in results.items():
+            print(f"    {label:10} {res['clips'][wav.name]['text']}")
+
+    if args.json:
+        payload = {}
+        for label, res in results.items():
+            entry = {k: v for k, v in res.items() if k != "clips"}
+            entry["clips"] = {n: {k: v for k, v in c.items() if k != "encoded"} for n, c in res["clips"].items()}
+            payload[label] = entry
+        args.json.write_text(
+            json.dumps({"audio_seconds": total_seconds, "reference": reference_label, "builds": payload}, indent=2),
+            encoding="utf-8",
+        )
+        print(f"\nWrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quantize_parakeet_encoder.py
+++ b/scripts/quantize_parakeet_encoder.py
@@ -21,14 +21,31 @@ DynamicQuantizeLinear. Two consequences:
 Weight-only quantization stores just the *weights* as int8 and dequantizes
 each block back to fp16 at runtime, so the arithmetic keeps fp16 precision.
 It compiles to a single op, MatMulNBits, which ORT Web *does* implement on
-WebGPU as well as on CPU. One file then serves both paths:
-
-    ~0.65 GB      vs 1.26 GB for fp16 — half the download
-    GPU           same speed and accuracy as fp16
-    CPU           same weights, so near-lossless instead of the above
+WebGPU as well as on CPU, so one file can serve both paths.
 
 8 bits, not 4: measured through six stacked layers, 8-bit weight-only came
 out at 1.6% relative error while 4-bit hit 24%. 4-bit is not usable here.
+
+Measured on the real encoder
+────────────────────────────
+By scripts/eval_parakeet_encoders.py, against the fp32 encoder over 47 s of
+speech (six clips, English and Spanish), everything on the CPU:
+
+    file          896 MB — 217 of 289 MatMuls became MatMulNBits. Not the
+                  ~650 MB predicted: 302 MB of the encoder is pointwise Conv
+                  weights, which this quantizer leaves in fp32.
+    accuracy      1.8% encoder output error, and identical transcripts on
+                  every clip. The upstream *dynamic* int8 file scores 44%
+                  encoder error on the same audio.
+    CPU speed     3.2-3.4x realtime, against 7.6-9.3x for the dynamic int8
+                  file — weight-only is ~2.5x *slower* on the CPU, because
+                  MatMulNBits dequantizes per block on every pass while
+                  MatMulInteger runs as straight int8 GEMM.
+
+So the accuracy case holds and the size case is weaker than hoped, but a CPU
+device pays for it in speed. What is still unmeasured is the WebGPU side,
+where MatMulNBits has a kernel and the dynamic int8 ops have none.
+
 
 Usage
 ─────

--- a/scripts/quantize_parakeet_encoder.py
+++ b/scripts/quantize_parakeet_encoder.py
@@ -31,20 +31,25 @@ Measured on the real encoder
 By scripts/eval_parakeet_encoders.py, against the fp32 encoder over 47 s of
 speech (six clips, English and Spanish), everything on the CPU:
 
-    file          896 MB — 217 of 289 MatMuls became MatMulNBits. Not the
-                  ~650 MB predicted: 302 MB of the encoder is pointwise Conv
-                  weights, which this quantizer leaves in fp32.
-    accuracy      1.8% encoder output error, and identical transcripts on
-                  every clip. The upstream *dynamic* int8 file scores 44%
-                  encoder error on the same audio.
-    CPU speed     3.2-3.4x realtime, against 7.6-9.3x for the dynamic int8
-                  file — weight-only is ~2.5x *slower* on the CPU, because
-                  MatMulNBits dequantizes per block on every pass while
-                  MatMulInteger runs as straight int8 GEMM.
+                    size    CPU speed   encoder error   WER
+    fp32           2477 MB    7.2-7.8x       —           —
+    weight-only     896 MB    3.2-3.9x      1.8%        0.0%
+    + convs folded  672 MB    2.8x          1.9%        0.0%
+    dynamic int8    652 MB    7.6-9.3x     44.0%        1.8%
 
-So the accuracy case holds and the size case is weaker than hoped, but a CPU
-device pays for it in speed. What is still unmeasured is the WebGPU side,
-where MatMulNBits has a kernel and the dynamic int8 ops have none.
+The accuracy case is settled: weight-only int8 reproduces the fp32
+transcripts word for word, in both languages, either way. Two costs came out
+worse than predicted:
+
+  * Size needed the conv fold to reach ~0.65 GB. Plain weight-only leaves
+    302 MB of pointwise Conv weights in fp32 — see fold_pointwise_convs.
+  * CPU speed drops ~2.5x against the dynamic int8 file, because
+    MatMulNBits dequantizes per block on every pass while MatMulInteger
+    runs as a straight int8 GEMM. Folding the convs costs a further ~28%,
+    trading it for the 224 MB.
+
+What is still unmeasured is the WebGPU side, the reason the file exists:
+MatMulNBits has a WebGPU kernel and the dynamic int8 ops have none.
 
 
 Usage
@@ -144,12 +149,95 @@ def count_ops(model) -> dict[str, int]:
     return counts
 
 
-def quantize(encoder_path: Path, out_path: Path, bits: int, block_size: int) -> None:
+def fold_pointwise_convs(model) -> int:
+    """Rewrite every 1x1 grouped-by-1 Conv as Transpose-MatMul-Transpose.
+
+    A pointwise conv over [N, C_in, T] is arithmetically a MatMul: each time
+    step is multiplied by the same [C_in, C_out] matrix. ONNX keeps them as
+    Conv, and MatMulNBitsQuantizer only rewrites MatMul — so in the Parakeet
+    encoder the 48 pointwise convs of the conformer conv modules (302 MB of
+    the 2.4 GB) would stay fp32 and dominate the quantized file.
+
+    MatMul contracts over the *last* axis, so the channel axis has to come
+    last: hence a Transpose on either side. Those are bandwidth, not
+    arithmetic, and the conformer conv module already transposes around this
+    block, so ORT's transpose optimizer cancels most of them at load.
+
+    Depthwise convs (group == channels) are left alone: they hold little
+    weight and are not matrix products. Returns the number folded.
+    """
+    import numpy as np
+    from onnx import helper, numpy_helper
+
+    graph = model.graph
+    initializers = {init.name: init for init in graph.initializer}
+    produced_here = set()
+    new_nodes = []
+    folded = 0
+
+    for node in graph.node:
+        weight = initializers.get(node.input[1]) if node.op_type == "Conv" and len(node.input) >= 2 else None
+        attrs = {a.name: list(a.ints) if a.ints else a.i for a in node.attribute}
+        eligible = (
+            weight is not None
+            and len(weight.dims) == 3  # [C_out, C_in, 1] — the 1-D convs
+            and weight.dims[2] == 1
+            and attrs.get("group", 1) == 1
+            and attrs.get("strides", [1]) == [1]
+            and attrs.get("dilations", [1]) == [1]
+            and not any(attrs.get("pads", [0, 0]))
+        )
+        if not eligible:
+            new_nodes.append(node)
+            continue
+
+        base = node.name or f"conv_{folded}"
+        x, out = node.input[0], node.output[0]
+
+        # [C_out, C_in, 1] -> [C_in, C_out], the B operand of a MatMul.
+        w = numpy_helper.to_array(weight).reshape(weight.dims[0], weight.dims[1]).T
+        w_name = f"{base}/matmul_weight"
+        graph.initializer.append(numpy_helper.from_array(np.ascontiguousarray(w), w_name))
+
+        pre, mm, post = f"{base}/nct", f"{base}/matmul", f"{base}/ntc"
+        new_nodes.append(helper.make_node("Transpose", [x], [pre], name=f"{base}/pre", perm=[0, 2, 1]))
+        new_nodes.append(helper.make_node("MatMul", [pre, w_name], [mm], name=mm))
+        last = mm
+        if len(node.input) > 2:  # bias [C_out] broadcasts over the last axis
+            last = f"{base}/biased"
+            new_nodes.append(helper.make_node("Add", [mm, node.input[2]], [last], name=f"{base}/add"))
+        new_nodes.append(helper.make_node("Transpose", [last], [out], name=f"{base}/post", perm=[0, 2, 1]))
+
+        produced_here.update({pre, mm, last})
+        folded += 1
+
+    if not folded:
+        return 0
+
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    # Drop the now-unused Conv weights, then let ONNX re-derive shapes for the
+    # tensors we introduced.
+    keep = {name for node in graph.node for name in node.input}
+    stale = [init for init in graph.initializer if init.name not in keep]
+    for init in stale:
+        graph.initializer.remove(init)
+    graph.value_info.extend(helper.make_empty_tensor_value_info(name) for name in sorted(produced_here))
+    # No onnx.checker here: it serializes the model to bytes, and the fp32
+    # encoder is over the 2 GB protobuf limit. The quantized result is checked
+    # for real by verify(), which loads it in ONNX Runtime.
+    return folded
+
+
+def quantize(encoder_path: Path, out_path: Path, bits: int, block_size: int, fold_convs: bool = True) -> None:
     import onnx
     from onnxruntime.quantization import matmul_nbits_quantizer as q
 
     print(f"[load] {encoder_path.name} ({encoder_path.stat().st_size / 1e6:.0f} MB)")
     model = onnx.load(str(encoder_path))
+    if fold_convs:
+        folded = fold_pointwise_convs(model)
+        print(f"[fold] {folded} pointwise Conv -> MatMul" if folded else "[fold] no pointwise Conv found")
     before = count_ops(model)
 
     print(f"[quant] weight-only, {bits}-bit, block size {block_size} — takes a few minutes")
@@ -184,6 +272,63 @@ def verify(model_path: Path) -> None:
     print(f"[check] loads OK\n        inputs : {ins}\n        outputs: {outs}")
 
 
+def write_model_card(out: Path, repo: str, bits: int, block_size: int, folded: bool) -> None:
+    """Write a Hugging Face model card, so `out` can be uploaded as-is."""
+    sizes = "\n".join(f"| `{p.name}` | {p.stat().st_size / 1e6:.0f} MB |" for p in sorted(out.iterdir()) if p.is_file() and p.suffix in (".onnx", ".txt"))
+    (out / "README.md").write_text(
+        f"""---
+license: cc-by-4.0
+base_model: {repo}
+library_name: onnx
+pipeline_tag: automatic-speech-recognition
+tags: [onnx, onnxruntime-web, webgpu, parakeet, tdt, asr, quantized]
+---
+
+# Parakeet TDT 0.6B v3 — weight-only int{bits} encoder (ONNX)
+
+The encoder of [{repo}](https://huggingface.co/{repo}), requantized so that
+**one file runs on both WebGPU and CPU** in ONNX Runtime Web. Built by
+[MeetScribe](https://github.com/hellguz/MeetScribe)'s
+`scripts/quantize_parakeet_encoder.py`; the decoder and vocabulary here are
+copied from the base repo unchanged.
+
+The upstream int8 encoder is *dynamically* quantized — weights and
+activations both — which compiles to `MatMulInteger` and
+`DynamicQuantizeLinear`. Neither op has a WebGPU kernel, so that file is
+CPU-only, and quantizing activations costs real accuracy. This build keeps
+int{bits} **weights** and fp16 arithmetic, which compiles to `MatMulNBits`
+(block size {block_size}) — implemented on WebGPU and on CPU.
+
+{"Pointwise convolutions are rewritten as MatMul before quantizing, so the conformer conv modules quantize too instead of staying fp32." if folded else "Pointwise convolutions are left as Conv, so their weights stay fp32."}
+
+| file | size |
+|---|---|
+{sizes}
+
+## Accuracy
+
+Against the fp32 encoder over 47 s of English and Spanish speech: **{"1.9" if folded else "1.8"}%**
+encoder output error, and **identical transcripts on every clip** (0.0% WER).
+The upstream dynamic int8 encoder scores 44% encoder error on the same audio.
+
+## Use
+
+Same interface as the base repo — `parakeet.js` or any ONNX Runtime Web
+setup. Inputs `audio_signal` [B, 128, T] (NeMo log-mel) and `length`;
+outputs `outputs` [B, 1024, T/8] and `encoded_lengths`. The identical
+weights are stored under both `encoder-model.int8.onnx` and
+`encoder-model.fp16.onnx` so a loader that picks a file per device gets this
+build either way.
+
+In MeetScribe, point the frontend at this repo:
+
+```
+VITE_PARAKEET_MODEL_BASE=https://huggingface.co/<user>/<repo>/resolve/main/
+```
+""",
+        encoding="utf-8",
+    )
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--out", type=Path, default=Path("parakeet-q8"), help="directory to write the servable model files into")
@@ -193,6 +338,7 @@ def main() -> int:
     parser.add_argument("--bits", type=int, default=8, choices=(4, 8), help="weight width; 4 measured 24%% error, so 8 unless you are experimenting")
     parser.add_argument("--block-size", type=int, default=128, help="weights per quantization block")
     parser.add_argument("--no-alias", action="store_true", help="write only the CPU plan's filename, not both")
+    parser.add_argument("--no-fold-convs", action="store_true", help="leave the pointwise convs as Conv, so they stay fp32 (~230 MB larger)")
     args = parser.parse_args()
 
     out: Path = args.out
@@ -203,7 +349,7 @@ def main() -> int:
     encoder = fetch_sources(args.repo, args.revision, workdir)
 
     primary = out / NAME_FOR_PLAN["cpu-int8"]
-    quantize(encoder, primary, args.bits, args.block_size)
+    quantize(encoder, primary, args.bits, args.block_size, fold_convs=not args.no_fold_convs)
     verify(primary)
 
     for name in (DECODER, VOCAB):
@@ -214,6 +360,8 @@ def main() -> int:
         # a clean A/B on speed alone.
         shutil.copyfile(primary, out / NAME_FOR_PLAN["gpu-fp16"])
 
+    write_model_card(out, args.repo, args.bits, args.block_size, not args.no_fold_convs)
+
     print(f"\nWrote to {out.resolve()}:")
     for path in sorted(out.iterdir()):
         if path.is_file():
@@ -221,7 +369,11 @@ def main() -> int:
     print(
         "\nServe that directory, then build the frontend with\n"
         f"  VITE_PARAKEET_MODEL_BASE=<url of {out.name}/> pnpm -C frontend build\n"
-        f"The fp32 source is still in {workdir}; delete it to reclaim the space."
+        "\nOr host it on Hugging Face, whose CDN already sends the CORS headers\n"
+        "the app needs (README.md is a model card for exactly that):\n"
+        f"  hf upload <user>/<repo> {out} . --repo-type=model\n"
+        f"  VITE_PARAKEET_MODEL_BASE=https://huggingface.co/<user>/<repo>/resolve/main/\n"
+        f"\nThe fp32 source is still in {workdir}; delete it to reclaim the space."
     )
     return 0
 

--- a/scripts/quantize_parakeet_encoder.py
+++ b/scripts/quantize_parakeet_encoder.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+scripts/quantize_parakeet_encoder.py
+───────────────────────────────────────────────────────────────────────────
+Builds a *weight-only* int8 Parakeet encoder for the on-device transcription
+mode (frontend/src/ondevice/), and writes it next to the other model files so
+`VITE_PARAKEET_MODEL_BASE` can point at the result.
+
+Why this exists
+───────────────
+The int8 encoder published upstream is *dynamically* quantized: weights AND
+activations become int8 at runtime, via the ops MatMulInteger and
+DynamicQuantizeLinear. Two consequences:
+
+  * ONNX Runtime Web has no WebGPU kernel for either op, so that file can
+    only ever run on the CPU.
+  * Quantizing activations costs real accuracy. Measured over a 30-minute
+    meeting it dropped 12% of the spoken words outright and substituted
+    another 15%, against the fp16 model as reference.
+
+Weight-only quantization stores just the *weights* as int8 and dequantizes
+each block back to fp16 at runtime, so the arithmetic keeps fp16 precision.
+It compiles to a single op, MatMulNBits, which ORT Web *does* implement on
+WebGPU as well as on CPU. One file then serves both paths:
+
+    ~0.65 GB      vs 1.26 GB for fp16 — half the download
+    GPU           same speed and accuracy as fp16
+    CPU           same weights, so near-lossless instead of the above
+
+8 bits, not 4: measured through six stacked layers, 8-bit weight-only came
+out at 1.6% relative error while 4-bit hit 24%. 4-bit is not usable here.
+
+Usage
+─────
+    pip install onnx onnxruntime onnx_ir
+    python scripts/quantize_parakeet_encoder.py --out ./parakeet-q8
+
+Then serve that directory (any static host) and build the frontend with
+VITE_PARAKEET_MODEL_BASE pointing at it.
+
+The fp32 encoder is ~2.4 GB, so expect a long download and ~6 GB of free
+disk while it runs. Nothing here touches the app at runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_REPO = "ysdede/parakeet-tdt-0.6b-v3-onnx"
+# parakeet.js pins the second branch for its fp16 assets; the fp32 encoder
+# lives on whichever of these answers first.
+REVISIONS = ("main", "feat/fp16-canonical-v3")
+
+FP32_ENCODER = "encoder-model.onnx"
+DECODER = "decoder_joint-model.int8.onnx"
+VOCAB = "vocab.txt"
+
+# What frontend/src/ondevice/hub.ts asks for, per plan. The same quantized
+# file is written under both names so either plan loads it unchanged.
+NAME_FOR_PLAN = {"cpu-int8": "encoder-model.int8.onnx", "gpu-fp16": "encoder-model.fp16.onnx"}
+
+
+def hf_url(repo: str, revision: str, filename: str) -> str:
+    return f"https://huggingface.co/{repo}/resolve/{revision}/{filename}"
+
+
+def download(url: str, dest: Path, optional: bool = False) -> bool:
+    """Stream `url` to `dest`. Returns False for an absent optional file."""
+    if dest.exists() and dest.stat().st_size > 0:
+        print(f"[skip] {dest.name} already present ({dest.stat().st_size / 1e6:.0f} MB)")
+        return True
+
+    print(f"[get ] {url}")
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        with urllib.request.urlopen(url, timeout=120) as response, tmp.open("wb") as out:
+            total = int(response.headers.get("content-length") or 0)
+            done = 0
+            while True:
+                block = response.read(1 << 20)
+                if not block:
+                    break
+                out.write(block)
+                done += len(block)
+                if total:
+                    pct = done / total * 100
+                    print(f"\r       {done / 1e6:7.0f} / {total / 1e6:.0f} MB ({pct:5.1f}%)", end="", flush=True)
+            print()
+    except urllib.error.HTTPError as exc:
+        tmp.unlink(missing_ok=True)
+        if optional and exc.code in (403, 404):
+            return False
+        raise SystemExit(f"could not download {url}: {exc}") from exc
+    except urllib.error.URLError as exc:
+        tmp.unlink(missing_ok=True)
+        raise SystemExit(f"could not download {url}: {exc}") from exc
+
+    tmp.replace(dest)
+    return True
+
+
+def fetch_sources(repo: str, revision: str | None, workdir: Path) -> Path:
+    """Download the fp32 encoder (plus decoder and vocab) into `workdir`."""
+    revisions = (revision,) if revision else REVISIONS
+    for rev in revisions:
+        encoder = workdir / FP32_ENCODER
+        if download(hf_url(repo, rev, FP32_ENCODER), encoder, optional=True):
+            # Models over the 2 GB protobuf limit keep their weights alongside.
+            download(hf_url(repo, rev, FP32_ENCODER + ".data"), workdir / (FP32_ENCODER + ".data"), optional=True)
+            for name in (DECODER, VOCAB):
+                download(hf_url(repo, rev, name), workdir / name)
+            print(f"[ok  ] using revision '{rev}'")
+            return encoder
+        print(f"[miss] {FP32_ENCODER} not on revision '{rev}'")
+    raise SystemExit(f"{FP32_ENCODER} not found in {repo} (tried: {', '.join(revisions)})")
+
+
+def count_ops(model) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for node in model.graph.node:
+        counts[node.op_type] = counts.get(node.op_type, 0) + 1
+    return counts
+
+
+def quantize(encoder_path: Path, out_path: Path, bits: int, block_size: int) -> None:
+    import onnx
+    from onnxruntime.quantization import matmul_nbits_quantizer as q
+
+    print(f"[load] {encoder_path.name} ({encoder_path.stat().st_size / 1e6:.0f} MB)")
+    model = onnx.load(str(encoder_path))
+    before = count_ops(model)
+
+    print(f"[quant] weight-only, {bits}-bit, block size {block_size} — takes a few minutes")
+    config = q.DefaultWeightOnlyQuantConfig(bits=bits, block_size=block_size, is_symmetric=True)
+    quantizer = q.MatMulNBitsQuantizer(model, algo_config=config)
+    quantizer.process()
+
+    # The quantized model is well under the 2 GB protobuf limit, so keep it as
+    # a single file: hub.ts then needs no .data sidecar.
+    quantizer.model.save_model_to_file(str(out_path), use_external_data_format=False)
+
+    after = count_ops(onnx.load(str(out_path)))
+    converted = after.get("MatMulNBits", 0)
+    print(f"[quant] MatMul {before.get('MatMul', 0)} -> MatMulNBits {converted}")
+    if converted == 0:
+        raise SystemExit(
+            "no MatMul nodes were quantized — the encoder may use Gemm instead, "
+            "which this quantizer does not rewrite."
+        )
+    left = before.get("MatMul", 0) - after.get("MatMul", 0) - converted
+    if left:
+        print(f"[warn] {abs(left)} MatMul node(s) unaccounted for; check the model")
+
+
+def verify(model_path: Path) -> None:
+    """Load the result and print its signature, so a broken file fails here."""
+    import onnxruntime as ort
+
+    session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    ins = ", ".join(f"{i.name}{i.shape}" for i in session.get_inputs())
+    outs = ", ".join(f"{o.name}{o.shape}" for o in session.get_outputs())
+    print(f"[check] loads OK\n        inputs : {ins}\n        outputs: {outs}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out", type=Path, default=Path("parakeet-q8"), help="directory to write the servable model files into")
+    parser.add_argument("--workdir", type=Path, default=None, help="where to keep the fp32 download (default: <out>/.src)")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="Hugging Face repo holding the fp32 encoder")
+    parser.add_argument("--revision", default=None, help="pin a branch instead of trying main then the fp16 branch")
+    parser.add_argument("--bits", type=int, default=8, choices=(4, 8), help="weight width; 4 measured 24%% error, so 8 unless you are experimenting")
+    parser.add_argument("--block-size", type=int, default=128, help="weights per quantization block")
+    parser.add_argument("--no-alias", action="store_true", help="write only the CPU plan's filename, not both")
+    args = parser.parse_args()
+
+    out: Path = args.out
+    out.mkdir(parents=True, exist_ok=True)
+    workdir: Path = args.workdir or (out / ".src")
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    encoder = fetch_sources(args.repo, args.revision, workdir)
+
+    primary = out / NAME_FOR_PLAN["cpu-int8"]
+    quantize(encoder, primary, args.bits, args.block_size)
+    verify(primary)
+
+    for name in (DECODER, VOCAB):
+        shutil.copyfile(workdir / name, out / name)
+
+    if not args.no_alias:
+        # Both plans then load these identical weights, which makes GPU vs CPU
+        # a clean A/B on speed alone.
+        shutil.copyfile(primary, out / NAME_FOR_PLAN["gpu-fp16"])
+
+    print(f"\nWrote to {out.resolve()}:")
+    for path in sorted(out.iterdir()):
+        if path.is_file():
+            print(f"  {path.name:34} {path.stat().st_size / 1e6:8.1f} MB")
+    print(
+        "\nServe that directory, then build the frontend with\n"
+        f"  VITE_PARAKEET_MODEL_BASE=<url of {out.name}/> pnpm -C frontend build\n"
+        f"The fp32 source is still in {workdir}; delete it to reclaim the space."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/serve_models.mjs
+++ b/scripts/serve_models.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * scripts/serve_models.mjs
+ * ───────────────────────────────────────────────────────────────────────────
+ * Serves a directory of Parakeet model files to the frontend, so
+ * VITE_PARAKEET_MODEL_BASE can point at a locally built model (see
+ * scripts/quantize_parakeet_encoder.py) instead of Hugging Face.
+ *
+ *   node scripts/serve_models.mjs ./data/parakeet-q8
+ *   VITE_PARAKEET_MODEL_BASE=http://localhost:8787/ pnpm -C frontend dev
+ *
+ * Three headers matter and a plain static server gets them wrong:
+ *
+ *   Access-Control-Allow-Origin  the app is cross-origin isolated
+ *     (Cross-Origin-Embedder-Policy: require-corp), so a cross-origin
+ *     subresource has to arrive as a CORS response or the browser drops it.
+ *   Cross-Origin-Resource-Policy the belt to that braces, for anything the
+ *     browser decides to fetch in no-cors mode.
+ *   Accept-Ranges / 206          frontend/src/ondevice/hub.ts probes for the
+ *     optional `.onnx.data` sidecar with a HEAD, falling back to a one-byte
+ *     ranged GET.
+ *
+ * Nothing here is used in production; the Docker image serves the frontend
+ * through nginx and the models come from wherever the build pointed.
+ */
+
+import { createReadStream, statSync } from "node:fs";
+import { createServer } from "node:http";
+import { extname, join, normalize, resolve, sep } from "node:path";
+
+const TYPES = {
+	".onnx": "application/octet-stream",
+	".data": "application/octet-stream",
+	".txt": "text/plain; charset=utf-8",
+	".json": "application/json; charset=utf-8",
+};
+
+const root = resolve(process.argv[2] ?? "./data/parakeet-q8");
+const port = Number(process.env.MODEL_PORT ?? 8787);
+
+try {
+	if (!statSync(root).isDirectory()) throw new Error("not a directory");
+} catch {
+	console.error(`[models] ${root} is not a directory.\nUsage: node scripts/serve_models.mjs <dir>`);
+	process.exit(1);
+}
+
+/** Resolve a request path inside `root`, or null if it escapes. */
+function safeJoin(urlPath) {
+	const decoded = decodeURIComponent(urlPath.split("?")[0]);
+	const target = resolve(join(root, normalize(decoded)));
+	return target === root || target.startsWith(root + sep) ? target : null;
+}
+
+const server = createServer((req, res) => {
+	const cors = {
+		"Access-Control-Allow-Origin": "*",
+		"Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+		"Access-Control-Allow-Headers": "Range, Content-Type",
+		"Access-Control-Expose-Headers": "Content-Length, Content-Range, Accept-Ranges",
+		"Cross-Origin-Resource-Policy": "cross-origin",
+		"Accept-Ranges": "bytes",
+	};
+
+	if (req.method === "OPTIONS") {
+		res.writeHead(204, cors).end();
+		return;
+	}
+	if (req.method !== "GET" && req.method !== "HEAD") {
+		res.writeHead(405, cors).end();
+		return;
+	}
+
+	const path = safeJoin(req.url ?? "/");
+	let stat;
+	try {
+		if (!path) throw new Error("outside root");
+		stat = statSync(path);
+		if (stat.isDirectory()) throw new Error("directory");
+	} catch {
+		// hub.ts reads a 404 as "this optional file is absent", which is the
+		// answer for the `.onnx.data` sidecar of a single-file model.
+		console.log(`[models] ${req.method} ${req.url} -> 404`);
+		res.writeHead(404, { ...cors, "Content-Type": "text/plain" }).end("not found\n");
+		return;
+	}
+
+	const headers = { ...cors, "Content-Type": TYPES[extname(path)] ?? "application/octet-stream" };
+	const range = /^bytes=(\d*)-(\d*)$/.exec(req.headers.range ?? "");
+
+	if (range) {
+		const start = range[1] ? Number(range[1]) : 0;
+		const end = range[2] ? Math.min(Number(range[2]), stat.size - 1) : stat.size - 1;
+		if (start > end || start >= stat.size) {
+			res.writeHead(416, { ...headers, "Content-Range": `bytes */${stat.size}` }).end();
+			return;
+		}
+		console.log(`[models] ${req.method} ${req.url} -> 206 ${start}-${end}`);
+		res.writeHead(206, { ...headers, "Content-Range": `bytes ${start}-${end}/${stat.size}`, "Content-Length": String(end - start + 1) });
+		if (req.method === "HEAD") res.end();
+		else createReadStream(path, { start, end }).pipe(res);
+		return;
+	}
+
+	console.log(`[models] ${req.method} ${req.url} -> 200 ${(stat.size / 1e6).toFixed(0)} MB`);
+	res.writeHead(200, { ...headers, "Content-Length": String(stat.size) });
+	if (req.method === "HEAD") res.end();
+	else createReadStream(path).pipe(res);
+});
+
+server.listen(port, () => {
+	console.log(`[models] serving ${root} on http://localhost:${port}/`);
+	console.log(`[models] build the frontend with VITE_PARAKEET_MODEL_BASE=http://localhost:${port}/`);
+});


### PR DESCRIPTION
## What

A **"⚡ Transcribe on this device"** toggle on the record page, for live recordings. Behind the toggle; nothing else changes.

- 🎤 **Transcription in the browser** — NVIDIA **Parakeet TDT 0.6B v3** (25 European languages) via `parakeet.js` / ONNX Runtime Web. Two plans, picked from device capabilities: **GPU** (WebGPU + `shader-f16`) or **CPU** (WASM). Files stream into the Cache API on first use, so a reload costs nothing, and each plan's chip shows the size measured from the host rather than a hardcoded guess.
- 🗣️ **Diarization in the browser** — the *same* pyannote + campplus ONNX models the server uses, ported from sherpa-onnx to TypeScript and validated against it (identical turns and speaker counts, boundaries within ~80 ms). The backend serves the two files (~36 MB) from `/api/models/…`.
- ☁️ **Summary still on Claude.** The server still stores audio and chunk texts as before; it just skips transcription and diarization for a meeting flagged `client_processing`.
- 📊 **Stats** in the panel, saved as `client_stats` and shown on the summary page: download size/speed/ETA, model load time, × realtime, diarization time, backend and thread count.
- ⚠️ **Per-device warnings**: no WebGPU → CPU path; iPhone/iPad → likely out of memory; phone → keep the screen on; not cross-origin isolated → single-threaded WASM.
- ↩️ **Fallback**: a model that fails to load, or a tab that dies mid-recording, hands the meeting back to the server pipeline (`/client-fallback`) using the audio already uploaded.

## Model files

`VITE_PARAKEET_MODEL_BASE` chooses where the browser fetches Parakeet from — unset means Hugging Face's upstream repo, which serves a 1.26 GB fp16 encoder to the GPU plan and a 0.65 GB dynamically quantized one to the CPU plan. It is now wired through the frontend Dockerfile and compose (it was only readable from a local `.env`) and documented in `.env.sample`.

Three scripts, none of them touched at runtime:

- **`scripts/quantize_parakeet_encoder.py`** builds a *weight-only* int8 encoder — **672 MB, one file for both plans**. The upstream int8 file quantizes activations too, which compiles to `MatMulInteger`/`DynamicQuantizeLinear`; neither has a WebGPU kernel, so that file is CPU-only. Weight-only compiles to `MatMulNBits`, which works on both. Pointwise convs are rewritten as MatMul first, so the conformer conv modules quantize instead of staying fp32 (896 MB → 672 MB). Writes a Hugging Face model card, so the output directory uploads as-is.
- **`scripts/eval_parakeet_encoders.py`** runs several encoder builds over the same audio in one runtime and reports size, speed, encoder output error and WER against a reference build. Feature extraction and greedy TDT decoding mirror `parakeet.js`.
- **`scripts/serve_models.mjs`** serves a local build with the CORS, CORP and ranged-GET headers a cross-origin-isolated page needs.

**ONNX Runtime is now 1.29 on the `onnxruntime-web/webgpu` entry.** The default entry ships ORT's older JSEP WebGPU implementation, whose `MatMulNBits` kernel accepts 4-bit weights only — an 8-bit encoder dies at session creation with `nbits_ == 4 was false`. The newer native WebGPU EP handles 2, 4 and 8 bits; it is the asyncify build, so it needs no JSPI and keeps working in Firefox and Safari, and it still registers the wasm backend for the CPU plan and diarization. `parakeet.js` creates the sessions itself through its own `import('onnxruntime-web')` against a pinned 1.24.1 dependency, so `vite.config.ts` aliases that to the exact file `ortSetup.ts` loads — as an absolute path, since a bare specifier resolves from parakeet.js's nested copy and silently builds two runtimes into the bundle. Frontend build image moved to node 22 for `import.meta.resolve`.

## Measured

**In-browser, 30-minute meeting** (Core Ultra 9 285H, Arc 140T, NVIDIA off), the two upstream plans:

| | GPU fp16 | CPU int8 |
|---|---|---|
| Speed | **15.4× realtime** | 6.3× |
| Download | 1.26 GB | 0.67 GB |
| Content words/min | **94.4** | 74.4 |
| Divergence from GPU | — | **27.6%** (12% dropped, 15% substituted) |

A Nothing 3a Pro measured **1.5× realtime** on the CPU plan — the floor that decides whether a CPU-only build is viable.

**Encoder builds on the CPU**, 47 s of English and Spanish speech, against the fp32 encoder (`eval_parakeet_encoders.py`, native ONNX Runtime):

| build | size | CPU speed | encoder error | WER |
|---|---|---|---|---|
| fp32 | 2477 MB | 7.2–7.8× | — | — |
| weight-only int8 | 896 MB | 3.2–3.9× | 1.8% | **0.0%** |
| + convs folded | 672 MB | 2.8× | 1.9% | **0.0%** |
| dynamic int8 (upstream CPU plan) | 652 MB | 7.6–9.3× | 44.0% | 1.8% |

So the weight-only build reproduces the fp32 transcripts word for word, and the file CPU devices download today does not — 44% encoder error is what surfaces as the 27.6% divergence above. The cost is CPU speed: ~2.5× slower than the dynamic file, which is why the phone number matters. On ORT 1.29 the 8-bit file **loads and runs on the GPU plan**; its × realtime there is not recorded in this description yet.

## Notes

- COOP/COEP headers added app-wide (Vite + nginx) so WASM runs multi-threaded; the Google Fonts link is now `crossorigin`.
- Backend: 2 new columns (with migration), 4 new endpoints; `finalize` skips server diarization for on-device meetings. "Re-run speakers" still works and switches the meeting back to server ownership.
- Live recordings only — file upload keeps the server path. Re-diarize stays server-side, since it needs the stored audio.
- Languages outside Parakeet's 25 (Japanese, Chinese, Arabic, Hindi, Turkish, Norwegian…) still need the server path.
- Verified end-to-end in headless Chromium with a fake mic playing a 4-speaker recording — mocked Parakeet, real diarization (70 s → 3 speakers in 4.4 s on 3 WASM threads) — plus the load-failure → server fallback path. The real Parakeet model has not been run in a browser from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
