### PR TITLE
🐌 fix: don't re-diarize when only the summary settings changed

### DIFF
--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -372,7 +372,17 @@ def rebuild_full_transcript(
     return transcript_text, len(chunks)
 
 
-def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
+def finalize_meeting_processing(
+    db: Session, mtg: Meeting, *, rediarize: bool = False
+) -> None:
+    """Build the transcript, summarize it, and title the meeting.
+
+    `rediarize` forces the audio back through the diarization pipeline. It is
+    for the explicit "find speakers" action only. Everything else — a fresh
+    recording, and every regenerate — leaves that decision to
+    `mtg.diarization_attempted`, so changing a summary setting re-summarizes
+    without re-decoding an hour of audio.
+    """
     LOGGER.info("Meeting %s: Finalizing. Building transcript and summarizing.", mtg.id)
     plain_transcript, num_chunks = rebuild_full_transcript(db, mtg.id)
 
@@ -383,18 +393,32 @@ def finalize_meeting_processing(db: Session, mtg: Meeting) -> None:
     final_transcript = plain_transcript
     duration_seconds = num_chunks * 30
 
-    if mtg.client_processing:
-        # The browser transcribed and diarized. It handed us the labelled
-        # transcript and the real duration via /finalize; if it never did
-        # (tab closed mid-way), the plain chunk texts are the best we have.
-        if mtg.transcript_text and mtg.transcript_text.strip():
-            final_transcript = mtg.transcript_text
+    # `rebuild_full_transcript` reassembles the *unlabelled* chunk texts, so a
+    # transcript we have already produced — labelled by the browser, or by an
+    # earlier diarization run — is strictly better. Reusing it is what makes a
+    # regenerate cheap; without this, the only way to get the speaker names
+    # back into the summary would be to diarize the audio all over again.
+    stored_transcript = bool(mtg.transcript_text and mtg.transcript_text.strip())
+    reuse_stored = (
+        stored_transcript
+        and not rediarize
+        and (mtg.client_processing or mtg.diarization_attempted)
+    )
+    if reuse_stored:
+        final_transcript = mtg.transcript_text
         if mtg.duration_seconds:
             duration_seconds = mtg.duration_seconds
         if mtg.processing_total is None:
             mtg.processing_total = 1
 
-    if plain_transcript and diarization.is_enabled() and not mtg.client_processing:
+    should_diarize = (
+        plain_transcript
+        and diarization.is_enabled()
+        and not mtg.client_processing
+        # Never twice by accident: only a first pass, or an explicit re-run.
+        and (rediarize or not mtg.diarization_attempted)
+    )
+    if should_diarize:
         # A fresh recording was transcribed live, so this run is diarize +
         # summarize. Reprocessing sets 3 before calling us.
         if mtg.processing_total is None:
@@ -712,7 +736,7 @@ def rediarize_meeting_in_worker(meeting_id_str: str, retranscribe: bool = True) 
             # From here on the server owns the transcript, even if the browser
             # produced the original one; finalize would otherwise keep it.
             mtg.client_processing = False
-            finalize_meeting_processing(db, mtg)
+            finalize_meeting_processing(db, mtg, rediarize=True)
             LOGGER.info("✅ Meeting %s re-diarized.", meeting_id_str)
 
     except Exception:


### PR DESCRIPTION
## 🐌 The bug

Changing a meeting's summary length, language or context re-ran **the entire diarization pipeline** — decoding every second of audio, then segmentation, embedding and clustering. On an hour-long meeting that is minutes of CPU per click, and it is why changing summary length has felt so much slower than it should.

`POST /regenerate` clears `done`, the next poll queues `generate_summary_only`, and that lands in `finalize_meeting_processing`, whose diarization gate tested only `client_processing`:

```python
if plain_transcript and diarization.is_enabled() and not mtg.client_processing:
```

No check on `diarization_attempted`. Every regenerate looked exactly like a first run.

## 🪤 Why it wasn't a one-line fix

The gate couldn't just be tightened. `finalize_meeting_processing` opens by calling `rebuild_full_transcript`, which reassembles the transcript from the **unlabelled** chunk texts and throws away the labelled `transcript_text`. Diarization was the only thing putting the speaker names back — skip it naively and every regenerated summary silently loses its speakers.

## ✅ The fix

Reuse the stored transcript. It is already the better one, and the on-device path three lines below was **already doing exactly this**; this generalises it to any meeting whose diarization has been attempted.

`rediarize` is keyword-only rather than inferred from meeting state: `rediarize_meeting_in_worker` is the one caller that genuinely wants the audio reprocessed, and it should have to say so.

## 🧪 Worth checking after merge

- Change summary length on a diarized meeting → speakers survive, no diarization in the logs
- "Find speakers" on an old meeting → still re-runs fully
- A fresh recording → diarizes once, as before

Independent of the Local mode work; safe to merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
